### PR TITLE
fix mfr image to export using the correct formats

### DIFF
--- a/mfr_image/__init__.py
+++ b/mfr_image/__init__.py
@@ -7,9 +7,9 @@ try:  # Exporter requires PIL
     exporter = ImageExporter()
     exporters = {
         'png': exporter.export_png,
-        # 'jpg': exporter.export_jpg,
+        'jpg': exporter.export_jpg,
         'gif': exporter.export_gif,
-        # 'tif': exporter.export_tif,
+        'tif': exporter.export_tif,
     }
 except ImportError:
     exporters = {}

--- a/mfr_image/export.py
+++ b/mfr_image/export.py
@@ -15,7 +15,7 @@ class ImageExporter(object):
     def export_jpg(self, fp):
         im = Image.open(fp)
         sio = StringIO()
-        im.save(sio, format='jpg')
+        im.save(sio, format='jpeg')
         return sio.getvalue()
 
     def export_gif(self, fp):
@@ -27,5 +27,5 @@ class ImageExporter(object):
     def export_tif(self, fp):
         im = Image.open(fp)
         sio = StringIO()
-        im.save(sio, format='tif')
+        im.save(sio, format='tiff')
         return sio.getvalue()


### PR DESCRIPTION
Pillow does not have a format jpg or tif. They use jpeg and tiff. Export now works correctly.
