### PR TITLE
Make CLI install modules matching 'mfr_[module]'

### DIFF
--- a/mfr/cli.py
+++ b/mfr/cli.py
@@ -2,6 +2,7 @@
 """Command Line tool for the modular file renderer"""
 
 import os
+import re
 import pip
 import sys
 import argparse
@@ -32,7 +33,10 @@ def plugin_requirements(render, export, plugins):
 
     if plugins == ["all"]:
         path_list = [os.path.join(ROOT_PATH, directory)
-                     for directory in os.listdir(ROOT_PATH)]
+                     for directory in os.listdir(ROOT_PATH)
+                        if bool(re.match('mfr_\w*',
+                            directory.split('/')[len(directory.split('/')) - 1]))]
+
     else:
         path_list = [os.path.join(ROOT_PATH, plugin) for plugin in plugins]
 

--- a/mfr_pdb/render-requirements.txt
+++ b/mfr_pdb/render-requirements.txt
@@ -1,1 +1,0 @@
-git+https://github.com/biasmv/pv.git

--- a/mfr_pdb/render.py
+++ b/mfr_pdb/render.py
@@ -1,11 +1,12 @@
 """Molecule renderer module """
-
+#Uses PV: https://github.com/biasmv/pv
 import os
 import mfr
 from mfr.core import RenderResult, get_assets_from_list
 
 # assets must be loaded in this order
 JS_ASSETS = [
+    #The OSF has jquery on each page, uncomment if necessary (e.g. for the player)
     #'jquery-1.7.min.js',
     'modernizr.js',
     'foundation-5.4.7.min.js',


### PR DESCRIPTION
Purpose
=======
* Limit dirs/files searched to only directories with valid naming convention when calling <code>mfr install all<code>
* Closes https://github.com/CenterForOpenScience/modular-file-renderer/issues/122

Changes
=======
Ignores non-directories and non-matching directories when installing plugins

Side Effects
==========
Removes unnecessary render-requirements.txt from mfr_pdb 