### PR TITLE
Resize canvas on initial load

### DIFF
--- a/mfr/ext/pdf/templates/pdfpage.mako
+++ b/mfr/ext/pdf/templates/pdfpage.mako
@@ -86,6 +86,7 @@
             $prevButton.css("height", navBarHeight);
             $nextButton.css("height",navBarHeight);
             page.render(renderContext);
+            resizeCanvas();
         });
 
 


### PR DESCRIPTION
Purpose
=======
The pdf forward/back buttons scale to initial size of canvas on load and whenever the window/zoom is changed, but don't resize themselves when the pdf is first loaded into the canvas.

Changes
=======
Call <code>resizeCanvas()</code> immediately after the pdf is rendered.

Side Effects
==========
None