### PR TITLE
Hotfix/static collecting

### DIFF
--- a/mfr/core.py
+++ b/mfr/core.py
@@ -338,8 +338,8 @@ def copy_dir(src, dest):
     except shutil.Error as err:
         logger.warn(err)
     except OSError as err:
-        if os.path.exists(src):
-            logger.debug('Skipping {src} (already exists)'.format(src=src))
+        if os.path.exists(dest):
+            logger.debug('Skipping {dest} (already exists)'.format(dest=dest))
         else:
             raise err
 

--- a/mfr/core.py
+++ b/mfr/core.py
@@ -372,4 +372,5 @@ def collect_static(dest=None, dry_run=False):
             print('Pretending to copy {static_path} to {namespaced_destination}.'
                 .format(**locals()))
         else:
-            copy_dir(static_path, namespaced_destination)
+            if os.path.exists(static_path):
+                copy_dir(static_path, namespaced_destination)

--- a/mfr/core.py
+++ b/mfr/core.py
@@ -338,7 +338,10 @@ def copy_dir(src, dest):
     except shutil.Error as err:
         logger.warn(err)
     except OSError as err:
-        logger.debug('Skipping {src} (already exists)'.format(src=src))
+        if os.path.exists(src):
+            logger.debug('Skipping {src} (already exists)'.format(src=src))
+        else:
+            raise err
 
 
 def get_namespace(handler_cls):


### PR DESCRIPTION
Purpose
=======
OSErrors unrelated to files already existing (such as permissions errors) caught during collect_static() should not be allowed to pass silently.
Closes https://github.com/CenterForOpenScience/modular-file-renderer/issues/138

Changes
========
When an OSError is caught, check to see if the path exists. If not, it's an unrelated error and is raised.

Side Effects
==========
OSErrors might be raised.