### PR TITLE
Default to TextLexer if default lexer cannot be found

### DIFF
--- a/mfr/ext/code_pygments/__init__.py
+++ b/mfr/ext/code_pygments/__init__.py
@@ -398,6 +398,7 @@ EXTENSIONS = [
     '.tt',
     '.twig',
     '.txt',
+    '.md',
     '.u',
     '.v',
     '.vala',

--- a/mfr/ext/code_pygments/render.py
+++ b/mfr/ext/code_pygments/render.py
@@ -2,13 +2,17 @@
 
 import pygments
 import pygments.lexers
+import pygments.lexers.special
 import pygments.formatters
+from pygments.util import ClassNotFound
 
 from mfr import config as core_config
 from mfr import RenderResult
 
 from .configuration import config as module_config
 
+
+DEFAULT_LEXER = pygments.lexers.special.TextLexer
 
 def render_html(fp, *args, **kwargs):
     """Generate an html representation of the file
@@ -18,7 +22,10 @@ def render_html(fp, *args, **kwargs):
     """
     formatter = pygments.formatters.HtmlFormatter(cssclass=module_config['CSS_CLASS'])
     content = fp.read()
-    lexer = pygments.lexers.guess_lexer_for_filename(fp.name, content)
+    try:
+        lexer = pygments.lexers.guess_lexer_for_filename(fp.name, content)
+    except ClassNotFound:
+        lexer = DEFAULT_LEXER()
     content = pygments.highlight(content, lexer, formatter)
     assets = {"css": [get_stylesheet()]}
     return RenderResult(content=content, assets=assets)

--- a/mfr/ext/code_pygments/tests/test_code_pygments.py
+++ b/mfr/ext/code_pygments/tests/test_code_pygments.py
@@ -26,6 +26,7 @@ def teardown_function(func):
     'script.PY',
     'script.RB',
     'script.JS',
+    'script.md',
 ])
 def test_detect_common_extensions(fakefile, filename):
     fakefile.name = filename
@@ -59,6 +60,12 @@ def test_configuration_defaults():
 
 def test_render_returns_render_result():
     with open(os.path.join(HERE, 'test_code_pygments.py')) as fp:
+        result = render_html(fp)
+
+    assert type(result) == mfr.core.RenderResult
+
+def test_renders_md():
+    with open(os.path.join(HERE, 'foo.md')) as fp:
         result = render_html(fp)
 
     assert type(result) == mfr.core.RenderResult


### PR DESCRIPTION
Adds back support for `.md` files in `ext.code_pygments`. 

Fixes https://trello.com/c/2Rjygl8y/354-markdown-files-fail-to-render