### PR TITLE
Pin to old, working version of IPy

### DIFF
--- a/mfr/ext/ipynb/render-requirements.txt
+++ b/mfr/ext/ipynb/render-requirements.txt
@@ -1,1 +1,1 @@
-ipython==2.1.0
+ipython<3.0

--- a/mfr/ext/ipynb/render-requirements.txt
+++ b/mfr/ext/ipynb/render-requirements.txt
@@ -1,1 +1,1 @@
-ipython>=2.1.0
+ipython==2.1.0


### PR DESCRIPTION
Purpose
=======
Build fails due to recent update of IPython to 3.0

Changes
=======
Pin IPy to 2.1.0

Side Effects
=========
None