### PR TITLE
Handle unicode characters in table files; add regression test.

### DIFF
--- a/mfr/ext/tabular/libs/panda_tools.py
+++ b/mfr/ext/tabular/libs/panda_tools.py
@@ -1,5 +1,4 @@
 import pandas
-import re
 from tempfile import NamedTemporaryFile
 from ..utilities import header_population, strip_comments
 

--- a/mfr/ext/tabular/tests/fixtures/test.csv
+++ b/mfr/ext/tabular/tests/fixtures/test.csv
@@ -1,3 +1,3 @@
 one,two,three
-a,b,c
+à,b,c
 1,2,3

--- a/mfr/ext/tabular/tests/test_panda_tools.py
+++ b/mfr/ext/tabular/tests/test_panda_tools.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import os
 from ..libs import panda_tools
 
@@ -16,7 +18,7 @@ def test_csv_pandas():
         headers, data = panda_tools.csv_pandas(fp)
 
     assert headers[0] == {'field': 'one', 'id': 'one', 'name': 'one'}
-    assert data[0] == {'one': 'a', 'two': 'b', 'three': 'c'}
+    assert data[0] == {'one': 'à', 'two': 'b', 'three': 'c'}
 
 
 def test_tsv_pandas():

--- a/mfr/ext/tabular/utilities.py
+++ b/mfr/ext/tabular/utilities.py
@@ -1,4 +1,9 @@
+# -*- coding: utf-8 -*-
+
 import re
+
+from mfr import compat
+
 
 def header_population(headers):
     """make column headers from a list
@@ -15,7 +20,6 @@ def data_population(in_data, headers=None):
     :param fields: column headers
     :return: JSON representation of rows
     """
-
     headers = headers or in_data[0]
 
     return [
@@ -24,7 +28,12 @@ def data_population(in_data, headers=None):
         for row in in_data
     ]
 
+
 def strip_comments(src, dest):
-    data = re.sub('%.*?\n', '', src.read()).encode('ascii', 'ignore')
+    data = re.sub('%.*?\n', '', src.read())
+    # Destination temp file is opened in binary mode; must cast contents to
+    # bytes before writing.
+    if isinstance(data, compat.unicode):
+        data = data.encode('utf-8', 'ignore')
     dest.write(data)
     dest.seek(0)


### PR DESCRIPTION
The `strip_comments` helper was previously attempting to encode
(potentially) bytestrings to bytestrings, which caused rendering with
non-ascii characters to fail. This patch only decodes to bytes if
necessary, and updates the csv test fixture with a unicode character to
prevent future regressions.

@sloria @mfraezz: This fixes the problem I was running into on OSF, but open to a better solution if this one is not rad.