### PR TITLE
Display special characters

### DIFF
--- a/mfr/ext/docx/render.py
+++ b/mfr/ext/docx/render.py
@@ -14,4 +14,4 @@ if not sys.version_info >= (3, 0):
         :return: RenderResult object containing the content html
         """
         content = Docx2Html(fp).parsed_without_head
-        return RenderResult(content=content.encode('ascii', 'ignore'), assets={})
+        return RenderResult(content=content)


### PR DESCRIPTION
Purpose
=======
Display special characters that were being ignored.
Closes: https://github.com/CenterForOpenScience/osf.io/issues/1739

![screen shot 2015-03-09 at 15 54 21 1](https://cloud.githubusercontent.com/assets/5659262/6563057/9f8169ae-c674-11e4-832d-9ce04c284ac0.png)

Changes
=======
Remove code that was originally used to fix a now unreproducible bug

Side Effects
=========
A UnicodeDecodeError may show up somewhere, somehow