### PR TITLE
Set tabular width to 'inherit' to prevent overlapping

### DIFF
--- a/mfr/ext/tabular/configuration.py
+++ b/mfr/ext/tabular/configuration.py
@@ -27,7 +27,6 @@ config = Config(defaults={
         # '.ods': [ods_ezodf],
     },
     'max_size': 10000,
-    'table_width': 700,  # pixels
     'table_height': 600,  # pixels
     'slick_grid_options': {
         'small_table': {

--- a/mfr/ext/tabular/render.py
+++ b/mfr/ext/tabular/render.py
@@ -39,7 +39,6 @@ def render_html(fp, src=None):
     columns, rows = populate_data(fp)
 
     max_size = config['max_size']
-    table_width = config['table_width']
     table_height = config['table_height']
 
     if len(columns) > max_size or len(rows) > max_size:
@@ -59,7 +58,6 @@ def render_html(fp, src=None):
 
     with open(TEMPLATE) as template:
         content = template.read().format(
-            width=table_width,
             height=table_height,
             columns=columns,
             rows=rows,

--- a/mfr/ext/tabular/templates/tabular.html
+++ b/mfr/ext/tabular/templates/tabular.html
@@ -1,4 +1,4 @@
-<div id="mfrGrid" style="width: {width}px; height: {height}px;"></div>
+<div id="mfrGrid" style="width: inherit; height: {height}px;"></div>
 
 <script>
 $().ready(function () {{


### PR DESCRIPTION
Purpose
=======
Closes https://github.com/CenterForOpenScience/osf.io/issues/2254

Changes
=======
Change how width is defined for tabular rendering. Height is left as it is (hard-coded to 600) because setting both to `inherit` makes the height default to 0, both in the MFR player and in the OSF, causing slickgrid to only display the column headers.

Side Effects
==========
None