### PR TITLE
Detect quotechars and doublequotes in csv dialect

### DIFF
--- a/mfr/extensions/tabular/libs/stdlib_tools.py
+++ b/mfr/extensions/tabular/libs/stdlib_tools.py
@@ -1,4 +1,5 @@
 import csv
+import re
 
 
 def csv_stdlib(fp):
@@ -37,13 +38,17 @@ def csv_stdlib(fp):
 
 def detect_quoted_fields(dialect, data):
     if dialect != csv.excel:
-        if data.find("''") >= 0:
-            dialect.doublequote = True
-            dialect.quotechar = "'"
+        if dialect.quotechar == '"':
+            if re.search('\'[[({]\".+\",', data):
+                dialect.quotechar = "'"
+            if re.search('\'\'\'[[({]\".+\",', data):
+                dialect.doublequote = True
             return dialect
-        elif data.find('""') >= 0:
-            dialect.doublequote = True
-            dialect.quotechar = '"'
+        elif dialect.quotechar == "'":
+            if re.search('\"[[({]\'.+\',', data):
+                dialect.quotechar = '"'
+            if re.search('\"\"\"[[({]\'.+\',', data):
+                dialect.doublequote = True
             return dialect
 
     return dialect

--- a/mfr/extensions/tabular/libs/stdlib_tools.py
+++ b/mfr/extensions/tabular/libs/stdlib_tools.py
@@ -49,12 +49,12 @@ def _set_dialect_quote_attrs(dialect, data):
         '{"a", "b", "c"         for quotechar == "
     """
     if dialect.quotechar == '"':
-        if re.search('\'[[({]\".+\",', data):
+        if re.search('\'[[({]".+",', data):
             dialect.quotechar = "'"
-        if re.search('\'\'\'[[({]\".+\",', data):
+        if re.search("'''[[({]\".+\",", data):
             dialect.doublequote = True
     elif dialect.quotechar == "'":
-        if re.search('\"[[({]\'.+\',', data):
+        if re.search("\"[[({]'.+',", data):
             dialect.quotechar = '"'
-        if re.search('\"\"\"[[({]\'.+\',', data):
+        if re.search('"""[[({]\'.+\',', data):
             dialect.doublequote = True

--- a/mfr/extensions/tabular/libs/stdlib_tools.py
+++ b/mfr/extensions/tabular/libs/stdlib_tools.py
@@ -14,8 +14,9 @@ def csv_stdlib(fp):
         dialect = csv.Sniffer().sniff(data)
     except csv.Error:
         dialect = csv.excel
+    else:
+        set_dialect_quote_attrs(dialect, data)
 
-    set_dialect_quote_attrs(dialect, data)
     reader = csv.DictReader(fp, dialect=dialect)
     columns = []
     # update the reader field names to avoid duplicate column names when performing row extraction

--- a/mfr/extensions/tabular/libs/stdlib_tools.py
+++ b/mfr/extensions/tabular/libs/stdlib_tools.py
@@ -15,7 +15,7 @@ def csv_stdlib(fp):
     except csv.Error:
         dialect = csv.excel
     else:
-        set_dialect_quote_attrs(dialect, data)
+        _set_dialect_quote_attrs(dialect, data)
 
     reader = csv.DictReader(fp, dialect=dialect)
     columns = []
@@ -37,7 +37,7 @@ def csv_stdlib(fp):
     return columns, rows
 
 
-def set_dialect_quote_attrs(dialect, data):
+def _set_dialect_quote_attrs(dialect, data):
     """Set quote-related dialect attributes based on up to 2kb of csv data.
 
     The regular expressions search for things that look like the beginning of

--- a/mfr/extensions/tabular/libs/stdlib_tools.py
+++ b/mfr/extensions/tabular/libs/stdlib_tools.py
@@ -41,7 +41,7 @@ def set_dialect_quote_attrs(dialect, data):
 
     The regular expressions search for things that look like the beginning of
     a list, wrapped in a quotation mark that is not dialect.quotechar, with
-    list items sepeted by commas.
+    list items wrapped in dialect.quotechar and seperated by commas.
 
     Example matches include:
         "['1', '2', '3'         for quotechar == '


### PR DESCRIPTION
Purpose
=======
Closes https://github.com/CenterForOpenScience/osf.io/issues/3817

Changes
=======
Add helper method to augment stdlib's csv.Sniffer for special cases.
Uses regex to look for comma-separated lists inside csv's

Side Effects
==========
None