### PR TITLE
Add rpy2 to render .sav files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,4 +32,5 @@ docutils==0.12
 
 # Tabular
 pandas==0.16.1
+rpy2==2.6.1
 git+https://github.com/icereval/xlrd.git


### PR DESCRIPTION
Purpose
=======
Closes https://github.com/CenterForOpenScience/osf.io/issues/2149
Allows for rendering of .sav (SPSS data) files. The code to do so is already present, but the library `rpy2`, required by pandas, is not being installed.

Changes
=======
Add `rpy2` to `requirements.txt`

Current .sav file behavior:
-------------------------------------
<img width="1280" alt="screen shot 2015-08-07 at 11 55 57" src="https://cloud.githubusercontent.com/assets/5659262/9139920/4c4d679e-3cfb-11e5-91cb-28eac9721ab6.png">

New behavior:
-------------------
<img width="1280" alt="screen shot 2015-08-07 at 11 56 39" src="https://cloud.githubusercontent.com/assets/5659262/9139936/696fd6f4-3cfb-11e5-87d9-b4a6aa16e47c.png">

Side effects:
==========
`gcc` must be installed. It is on our mfr server, according to @mattclark, and it is by default on most linux distributions. Brew installable on OS X.
`R` must be installed. This poses an issue for TCI.
