### PR TITLE
[Feature Fix] Refine MRF warning message not supporting rendering and exporting

### DIFF
--- a/mfr/core/utils.py
+++ b/mfr/core/utils.py
@@ -66,7 +66,7 @@ def make_exporter(name, source_file_path, output_file_path, format):
             invoke_args=(source_file_path, output_file_path, format),
         ).driver
     except RuntimeError:
-        raise exceptions.RendererError('No exporter could be found for the file type requested.', code=400)
+        raise exceptions.RendererError(settings.UNSUPPORTED_EXPORTER_MSG, code=400)
 
 
 def make_renderer(name, metadata, file_path, url, assets_url, export_url):
@@ -89,4 +89,4 @@ def make_renderer(name, metadata, file_path, url, assets_url, export_url):
             invoke_args=(metadata, file_path, url, assets_url, export_url),
         ).driver
     except RuntimeError:
-        raise exceptions.RendererError('Viewing of this file type within the OSF is not currently supported. Please download the file to view.', code=400)
+        raise exceptions.RendererError(settings.UNSUPPORTED_RENDER_MSG, code=400)

--- a/mfr/core/utils.py
+++ b/mfr/core/utils.py
@@ -89,4 +89,4 @@ def make_renderer(name, metadata, file_path, url, assets_url, export_url):
             invoke_args=(metadata, file_path, url, assets_url, export_url),
         ).driver
     except RuntimeError:
-        raise exceptions.RendererError('No renderer could be found for the file type requested.', code=400)
+        raise exceptions.RendererError('Viewing of this file type within the OSF is not currently supported. Please download the file to view.', code=400)

--- a/mfr/settings.py
+++ b/mfr/settings.py
@@ -6,6 +6,9 @@ import logging.config
 PROJECT_NAME = 'mfr'
 PROJECT_CONFIG_PATH = '~/.cos'
 
+UNSUPPORTED_EXPORTER_MSG = 'Exporting of this file type is not currently supported.'
+UNSUPPORTED_RENDER_MSG = 'Viewing of this file type is not currently supported. Please download the file to view.'
+
 try:
     import colorlog  # noqa
     DEFAULT_FORMATTER = {


### PR DESCRIPTION
### Purpose
The warning messages in MFR are too abstract to users. 
Resolve https://github.com/CenterForOpenScience/osf.io/issues/3907

### Changes
Move warning message into setting page and also change the text.

Change the warning message when dealing with non-supported file type
Old: `No renderer could be found for the file type requested.`
New: `Viewing of this file type is not currently supported. Please download the file to view.`

Change the warning message when dealing with non-exported file type
Old: `No exporter could be found for the file type requested.`
New: `Exporting of this file type is not currently supported.`

### Side Effect
None
