### PR TITLE
Additions to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,4 +69,7 @@ player/files/*
 player/mfr_config_local.py
 player/static/mfr/*
 
+# virtualenv stuff
+include
+
 !.gitkeep

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ dist
 /build
 eggs
 parts
+src
 bin
 var
 sdist
@@ -37,6 +38,7 @@ develop-eggs
 .installed.cfg
 lib
 lib64
+share
 __pycache__
 .idea
 .hg


### PR DESCRIPTION
following the build instructions leads to stuff being placed in the source tree which should not be committed. these are:
 - stuff from virtualenv
 - stuff from build dependencies

in this commit i add these to the .gitignore file