### PR TITLE
[Feature][Fix] Use case-insensitive search for tabular row filtering

### DIFF
--- a/mfr/extensions/tabular/templates/viewer.mako
+++ b/mfr/extensions/tabular/templates/viewer.mako
@@ -78,7 +78,8 @@
                 var filtered = false;
                 var item = data[i];
                 for (var title in item) {
-                    if (search !== "" && item[title].toString().indexOf(search) !== -1) {
+                    var re = new RegExp(search, 'i');
+                    if (search !== "" && item[title].toString().match(re)) {
                         filtered = filtered || true;
                         continue;
                     }

--- a/mfr/extensions/tabular/templates/viewer.mako
+++ b/mfr/extensions/tabular/templates/viewer.mako
@@ -74,11 +74,11 @@
 
         function filterData(data, search) {
             var filteredData = [];
+            var re = new RegExp(search, 'i');
             for (var i = 0; i<data.length; i++){
                 var filtered = false;
                 var item = data[i];
                 for (var title in item) {
-                    var re = new RegExp(search, 'i');
                     if (search !== '' && item[title].toString().match(re)) {
                         filtered = filtered || true;
                         continue;

--- a/mfr/extensions/tabular/templates/viewer.mako
+++ b/mfr/extensions/tabular/templates/viewer.mako
@@ -79,7 +79,7 @@
                 var item = data[i];
                 for (var title in item) {
                     var re = new RegExp(search, 'i');
-                    if (search !== "" && item[title].toString().match(re)) {
+                    if (search !== '' && item[title].toString().match(re)) {
                         filtered = filtered || true;
                         continue;
                     }


### PR DESCRIPTION
Purpose
=======
Search was case-sensitive, this can be annoying to users

Changes
=======
Use case insensitive RE matching. This was chosen over `.toUpperCase()` for special unicode characters.

Side Effects
=========
None