### PR TITLE
[Feature Fix] Add wrap in pre on Firefox [OSF-3532]

### DIFF
--- a/mfr/extensions/codepygments/static/css/default.css
+++ b/mfr/extensions/codepygments/static/css/default.css
@@ -61,3 +61,12 @@
 .highlight .vg { color: #19177C } /* Name.Variable.Global */
 .highlight .vi { color: #19177C } /* Name.Variable.Instance */
 .highlight .il { color: #666666 } /* Literal.Number.Integer.Long */
+
+/* CSS only for Firefox */
+@-moz-document url-prefix() {
+  .highlight > pre {
+      white-space: pre-wrap;       /*  css-3 */
+      white-space: -moz-pre-wrap;  /* Mozilla, since 1999 */
+      word-break: break-all;
+  }
+}

--- a/mfr/server/static/css/mfr.css
+++ b/mfr/server/static/css/mfr.css
@@ -70,12 +70,3 @@
 .embed-responsive-pdf {
     padding-bottom: 95%;
 }
-
-/* CSS only for Firefox */
-@-moz-document url-prefix() {
-  .highlight > pre {
-      white-space: pre-wrap;        /* css-3 */
-      white-space: -moz-pre-wrap;  /* Mozilla, since 1999 */
-      word-break: break-all;
-  }
-}

--- a/mfr/server/static/css/mfr.css
+++ b/mfr/server/static/css/mfr.css
@@ -70,3 +70,12 @@
 .embed-responsive-pdf {
     padding-bottom: 95%;
 }
+
+/* CSS only for Firefox */
+@-moz-document url-prefix() {
+  .highlight > pre {
+      white-space: pre-wrap;        /* css-3 */
+      white-space: -moz-pre-wrap;  /* Mozilla, since 1999 */
+      word-break: break-all;
+  }
+}


### PR DESCRIPTION
## Purpose
In Firefox, `word-wrap: break-word` will not break the line in pre-tag.  To test it, you can run the [link](http://jsfiddle.net/oc49Lv3y/1/) and compare the result of firefox with any other major browsers.

resolve [OSF-3532]
## Change
There are two possible solutions. One is to add new pre css and apply it to all browsers -- [Link](https://css-tricks.com/snippets/css/make-pre-text-wrap/). But it need to apply all the other browser. And also it requires to override a lot of css on bootstrap.

So I tried another method that is to add firefox specific css on mfr.css.

 *  The tricks to target css on firefox  -- [Link](https://css-tricks.com/snippets/css/css-hacks-targeting-firefox/). Add code specific for Firefox
~~~
@-moz-document url-prefix() { 
  .selector {
     color:lime;
  }
}
~~~

 *  Use `white-space` and `word-break` to mimic `word-wrap` in firefox  and make it as the same as Chrome and other browsers. [link] http://stackoverflow.com/questions/4282757/how-to-make-word-break-on-firefox-using-css
~~~
/* For Firefox */
white-space: pre-wrap;
word-break: break-all;

/* For Chrome and IE */
word-wrap: break-word;
~~~

## Side Effect 
None


