### PR TITLE
[feature] MFR Downscale Images (Fails to Render Large Images)

### DIFF
--- a/mfr/extensions/image/export.py
+++ b/mfr/extensions/image/export.py
@@ -7,8 +7,25 @@ from mfr.core import exceptions
 class ImageExporter(extension.BaseExporter):
 
     def export(self):
+        parts = self.format.split('.')
+        type = parts[-1].lower()
+        max_size = [int(x) for x in parts[0].split('x')] if len(parts) == 2 else None
         try:
             image = Image.open(self.source_file_path)
-            image.save(self.output_file_path)
+            if max_size:
+                # resize the image to the w/h maximum specified
+                ratio = min(max_size[0] / image.size[0], max_size[1] / image.size[1])
+                if ratio < 1:
+                    image = image.resize((round(image.size[0] * ratio), round(image.size[1] * ratio)), Image.ANTIALIAS)
+            if type in ['jpeg', 'jpg']:
+                # handle transparency
+                image = image.convert('RGBA')
+                exported_image = Image.new("RGBA", image.size, (255, 255, 255))
+                exported_image.paste(image, image)
+                image.close()
+            else:
+                exported_image = image
+            exported_image.save(self.output_file_path, type)
+            exported_image.close()
         except UnicodeDecodeError:
             raise exceptions.ExporterError('Unable to export the file in the requested format, please try again later.', code=400)

--- a/mfr/extensions/image/render.py
+++ b/mfr/extensions/image/render.py
@@ -20,7 +20,13 @@ class ImageRenderer(extension.BaseRenderer):
             return self.TEMPLATE.render(base=self.assets_url, url=self.url)
 
         exported_url = furl.furl(self.export_url)
-        exported_url.args['format'] = '{}.{}'.format(settings.EXPORT_MAXIMUM_SIZE, settings.EXPORT_TYPE)
+        if settings.EXPORT_MAXIMUM_SIZE and settings.EXPORT_TYPE:
+            exported_url.args['format'] = '{}.{}'.format(settings.EXPORT_MAXIMUM_SIZE, settings.EXPORT_TYPE)
+        elif settings.EXPORT_TYPE:
+            exported_url.args['format'] = settings.EXPORT_TYPE
+        else:
+            return self.TEMPLATE.render(base=self.assets_url, url=self.url)
+
         return self.TEMPLATE.render(base=self.assets_url, url=exported_url.url)
 
     @property

--- a/mfr/extensions/image/render.py
+++ b/mfr/extensions/image/render.py
@@ -16,8 +16,11 @@ class ImageRenderer(extension.BaseRenderer):
         ]).get_template('viewer.mako')
 
     def render(self):
+        if self.metadata.ext in settings.EXPORT_EXCLUSIONS:
+            return self.TEMPLATE.render(base=self.assets_url, url=self.url)
+
         exported_url = furl.furl(self.export_url)
-        exported_url.args['format'] = '{}.{}'.format(settings.MAXIMUM_SIZE, settings.TYPE)
+        exported_url.args['format'] = '{}.{}'.format(settings.EXPORT_MAXIMUM_SIZE, settings.EXPORT_TYPE)
         return self.TEMPLATE.render(base=self.assets_url, url=exported_url.url)
 
     @property

--- a/mfr/extensions/image/render.py
+++ b/mfr/extensions/image/render.py
@@ -1,8 +1,11 @@
 import os
 
+import furl
+
 from mako.lookup import TemplateLookup
 
 from mfr.core import extension
+from mfr.extensions.image import settings
 
 
 class ImageRenderer(extension.BaseRenderer):
@@ -13,7 +16,9 @@ class ImageRenderer(extension.BaseRenderer):
         ]).get_template('viewer.mako')
 
     def render(self):
-        return self.TEMPLATE.render(base=self.assets_url, url=self.url)
+        exported_url = furl.furl(self.export_url)
+        exported_url.args['format'] = '{}.{}'.format(settings.MAXIMUM_SIZE, settings.TYPE)
+        return self.TEMPLATE.render(base=self.assets_url, url=exported_url.url)
 
     @property
     def file_required(self):

--- a/mfr/extensions/image/settings.py
+++ b/mfr/extensions/image/settings.py
@@ -1,0 +1,9 @@
+try:
+    from mfr import settings
+except ImportError:
+    settings = {}
+
+config = settings.get('IMAGE_EXTENSION_CONFIG', {})
+
+TYPE = config.get('TYPE', 'jpeg')
+MAXIMUM_SIZE = config.get('MAXIMUM_SIZE', '1200x1200')

--- a/mfr/extensions/image/settings.py
+++ b/mfr/extensions/image/settings.py
@@ -7,4 +7,4 @@ config = settings.get('IMAGE_EXTENSION_CONFIG', {})
 
 EXPORT_TYPE = config.get('EXPORT_TYPE', 'jpeg')
 EXPORT_MAXIMUM_SIZE = config.get('EXPORT_MAXIMUM_SIZE', '1200x1200')
-EXPORT_EXCLUSIONS = config.get('EXPORT_EXCLUSION_MAP', ['.gif', ])
+EXPORT_EXCLUSIONS = config.get('EXPORT_EXCLUSIONS', ['.gif', ])

--- a/mfr/extensions/image/settings.py
+++ b/mfr/extensions/image/settings.py
@@ -5,5 +5,6 @@ except ImportError:
 
 config = settings.get('IMAGE_EXTENSION_CONFIG', {})
 
-TYPE = config.get('TYPE', 'jpeg')
-MAXIMUM_SIZE = config.get('MAXIMUM_SIZE', '1200x1200')
+EXPORT_TYPE = config.get('EXPORT_TYPE', 'jpeg')
+EXPORT_MAXIMUM_SIZE = config.get('EXPORT_MAXIMUM_SIZE', '1200x1200')
+EXPORT_EXCLUSIONS = config.get('EXPORT_EXCLUSION_MAP', ['.gif', ])

--- a/tests/extensions/image/test_renderer.py
+++ b/tests/extensions/image/test_renderer.py
@@ -1,43 +1,42 @@
 import pytest
 
+import furl
+
 from mfr.core.provider import ProviderMetadata
 
 from mfr.extensions.image import ImageRenderer
 from mfr.extensions.image import settings
 
 
-@pytest.fixture
-def metadata():
-    return ProviderMetadata('test', '.png', 'text/plain', '1234', 'http://wb.osf.io/file/test.png?token=1234')
-
-
-@pytest.fixture
-def file_path():
-    return '/tmp/test.png'
-
-
-@pytest.fixture
-def url():
-    return 'http://osf.io/file/test.png'
-
-
-@pytest.fixture
-def assets_url():
-    return 'http://mfr.osf.io/assets'
-
-
-@pytest.fixture
-def export_url():
-    return 'http://mfr.osf.io/export?url={}&format={}.{}'.format(url(), settings.MAXIMUM_SIZE, settings.TYPE)
-
-
-@pytest.fixture
-def renderer(metadata, file_path, url, assets_url, export_url):
-    return ImageRenderer(metadata, file_path, url, assets_url, export_url)
-
-
 class TestImageRenderer:
 
-    def test_render_image(self, renderer, export_url):
+    def test_render_image(self):
+        settings.EXPORT_TYPE_MAP = {}
+        settings.EXPORT_TYPE = 'fake_type'
+
+        url = 'http://osf.io/file/test.png'
+        export_url = furl.furl('http://mfr.osf.io/export')
+        export_url.args['url'] = url
+
+        metadata = ProviderMetadata('test', '.png', 'text/plain', '1234', 'http://wb.osf.io/file/test.png?token=1234')
+        renderer = ImageRenderer(metadata, '/tmp/test.png', url, 'http://mfr.osf.io/assets', export_url.url)
+
+        exported_url = furl.furl(export_url.url)
+        exported_url.args['format'] = '{}.{}'.format(settings.EXPORT_MAXIMUM_SIZE, settings.EXPORT_TYPE)
+
         body = renderer.render()
-        assert '<img style="max-width: 100%;" src="{}">'.format(export_url) in body
+
+        assert '<img style="max-width: 100%;" src="{}">'.format(exported_url) in body
+
+    def test_render_image_excluded_export(self):
+        settings.EXPORT_EXCLUSIONS = ['.png']
+        settings.EXPORT_TYPE = 'fake_type'
+
+        url = 'http://osf.io/file/test.png'
+
+        metadata = ProviderMetadata('test', '.png', 'text/plain', '1234', 'http://wb.osf.io/file/test.png?token=1234')
+        renderer = ImageRenderer(metadata, '/tmp/test.png', url, 'http://mfr.osf.io/assets', 'http://this_should_be_ignored')
+
+        body = renderer.render()
+
+        assert '<img style="max-width: 100%;" src="{}">'.format(url) in body

--- a/tests/extensions/image/test_renderer.py
+++ b/tests/extensions/image/test_renderer.py
@@ -10,8 +10,42 @@ from mfr.extensions.image import settings
 
 class TestImageRenderer:
 
-    def test_render_image(self):
+    def test_render_image_no_export(self):
         settings.EXPORT_TYPE_MAP = {}
+        settings.EXPORT_MAXIMUM_SIZE = None
+        settings.EXPORT_TYPE = None
+
+        url = 'http://osf.io/file/test.png'
+
+        metadata = ProviderMetadata('test', '.png', 'text/plain', '1234', 'http://wb.osf.io/file/test.png?token=1234')
+        renderer = ImageRenderer(metadata, '/tmp/test.png', url, 'http://mfr.osf.io/assets', 'http://this_should_be_ignored')
+
+        body = renderer.render()
+
+        assert '<img style="max-width: 100%;" src="{}">'.format(url) in body
+
+    def test_render_image_export_type(self):
+        settings.EXPORT_TYPE_MAP = {}
+        settings.EXPORT_MAXIMUM_SIZE = None
+        settings.EXPORT_TYPE = 'fake_type'
+
+        url = 'http://osf.io/file/test.png'
+        export_url = furl.furl('http://mfr.osf.io/export')
+        export_url.args['url'] = url
+
+        metadata = ProviderMetadata('test', '.png', 'text/plain', '1234', 'http://wb.osf.io/file/test.png?token=1234')
+        renderer = ImageRenderer(metadata, '/tmp/test.png', url, 'http://mfr.osf.io/assets', export_url.url)
+
+        exported_url = furl.furl(export_url.url)
+        exported_url.args['format'] =  settings.EXPORT_TYPE
+
+        body = renderer.render()
+
+        assert '<img style="max-width: 100%;" src="{}">'.format(exported_url) in body
+
+    def test_render_image_export_size_and_type(self):
+        settings.EXPORT_TYPE_MAP = {}
+        settings.EXPORT_MAXIMUM_SIZE = '1234x4321'
         settings.EXPORT_TYPE = 'fake_type'
 
         url = 'http://osf.io/file/test.png'
@@ -28,8 +62,23 @@ class TestImageRenderer:
 
         assert '<img style="max-width: 100%;" src="{}">'.format(exported_url) in body
 
-    def test_render_image_excluded_export(self):
+    def test_render_image_excluded_export_file_type(self):
         settings.EXPORT_EXCLUSIONS = ['.png']
+        settings.EXPORT_MAXIMUM_SIZE = None
+        settings.EXPORT_TYPE = 'fake_type'
+
+        url = 'http://osf.io/file/test.png'
+
+        metadata = ProviderMetadata('test', '.png', 'text/plain', '1234', 'http://wb.osf.io/file/test.png?token=1234')
+        renderer = ImageRenderer(metadata, '/tmp/test.png', url, 'http://mfr.osf.io/assets', 'http://this_should_be_ignored')
+
+        body = renderer.render()
+
+        assert '<img style="max-width: 100%;" src="{}">'.format(url) in body
+
+    def test_render_image_export_maximum(self):
+        settings.EXPORT_EXCLUSIONS = ['.png']
+        settings.EXPORT_MAXIMUM_SIZE = '1234x4321'
         settings.EXPORT_TYPE = 'fake_type'
 
         url = 'http://osf.io/file/test.png'

--- a/tests/extensions/image/test_renderer.py
+++ b/tests/extensions/image/test_renderer.py
@@ -3,6 +3,7 @@ import pytest
 from mfr.core.provider import ProviderMetadata
 
 from mfr.extensions.image import ImageRenderer
+from mfr.extensions.image import settings
 
 
 @pytest.fixture
@@ -27,7 +28,7 @@ def assets_url():
 
 @pytest.fixture
 def export_url():
-    return 'http://mfr.osf.io/export?url=' + url()
+    return 'http://mfr.osf.io/export?url={}&format={}.{}'.format(url(), settings.MAXIMUM_SIZE, settings.TYPE)
 
 
 @pytest.fixture
@@ -37,6 +38,6 @@ def renderer(metadata, file_path, url, assets_url, export_url):
 
 class TestImageRenderer:
 
-    def test_render_image(self, renderer, url):
+    def test_render_image(self, renderer, export_url):
         body = renderer.render()
-        assert '<img style="max-width: 100%;" src="{}">'.format(url) in body
+        assert '<img style="max-width: 100%;" src="{}">'.format(export_url) in body


### PR DESCRIPTION
Expand MFR's image export capabilities.
  - Handle transparency conversion w/ JPEG image format
  - Allows for optional maximum size (width x height)

Configures image renditions by default to an optimized format w/ configurable size and type settings.
  - JPEG @ 1200x1200 (the maximum bootstrap extra large monitor width currently supported on the osf is about 1100px)

[[OSF-4986]](https://openscience.atlassian.net/browse/OSF-4986)