### PR TITLE
Feature/md in ipynb

### DIFF
--- a/mfr/extensions/ipynb/templates/viewer.mako
+++ b/mfr/extensions/ipynb/templates/viewer.mako
@@ -2,7 +2,6 @@
 <link rel="stylesheet" href="${base}/css/pygments.css">
 <link rel="stylesheet" href="/static/css/default.css">
 
-
 <div style="word-wrap: break-word;" class="mfrViewer mfr-ipynb-body">
     ${body | n}
 </div>

--- a/mfr/extensions/ipynb/templates/viewer.mako
+++ b/mfr/extensions/ipynb/templates/viewer.mako
@@ -1,5 +1,7 @@
 <link rel="stylesheet" href="${base}/css/ipynb.css">
 <link rel="stylesheet" href="${base}/css/pygments.css">
+<link rel="stylesheet" href="/static/css/default.css">
+
 
 <div style="word-wrap: break-word;" class="mfrViewer mfr-ipynb-body">
     ${body | n}


### PR DESCRIPTION
Closes [#OSF-5884]
https://openscience.atlassian.net/browse/OSF-5884

# Purpose
The Notebooks Formerly known as iPython (now Jupyter) were being styled less-than-nicely when containing markdown text.

Make the ipython notebook template now style with default.css, for a nicer more uniform standard look

# Changes
- add ```default.css``` to ```mfr/extensions/ipynb/templates/viewer.mako```

before:
![screen shot 2016-03-17 at 4 33 57 pm](https://cloud.githubusercontent.com/assets/801594/13860324/1a7831fa-ec5e-11e5-9836-66824a6ee143.png)

after:
![screen shot 2016-03-17 at 4 33 28 pm](https://cloud.githubusercontent.com/assets/801594/13860336/240fc8c2-ec5e-11e5-8f4e-561176187f4a.png)

# Side effects
None anticipated, except ipython notebook files will look MORE AWESOME
