### PR TITLE
[CR] Convert MFR to use python-3.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,5 @@ player/mfr_config_local.py
 player/static/mfr/*
 
 !.gitkeep
+
+.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 python:
-  - "3.4"
+  - "3.5"
 
 sudo: false
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,3 @@
-decorator==3.4.0
 flake8==2.3.0
 pep8
 mccabe

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,30 +1,11 @@
-# Distribution
-# wheel
-# colorlog==2.5.0
-
-# Task runner
-# invoke
-
-# Docs
-# sphinx
-
-# Server
-# aiohttp==0.14.1
-# tornado==4.0.2
-# stevedore==1.2.0
-# git+https://github.com/jmcarp/raven-python
-# celery==3.1.17
-
-# Testing
-# mock
-# pytest
-# tox>=1.5.0
-
 decorator==3.4.0
 flake8==2.3.0
-ipdb==0.8
-pytest==2.6.4
-pytest-cov==1.8.1
+pep8
+mccabe
+pyflakes
+ipdb
+pytest==2.8.2
+pytest-cov==2.2.0
 pyzmq==14.4.1
 colorlog==2.5.0
 -e git+https://github.com/centerforopenscience/aiohttpretty.git#egg=aiohttpretty

--- a/mfr/providers/http/provider.py
+++ b/mfr/providers/http/provider.py
@@ -1,6 +1,6 @@
 import os
-import asyncio
 import hashlib
+import logging
 import mimetypes
 from urllib.parse import urlparse
 
@@ -11,20 +11,25 @@ from waterbutler.core import streams
 from mfr.core import provider
 from mfr.core import exceptions
 
+logger = logging.getLogger(__name__)
+
 
 class HttpProvider(provider.BaseProvider):
 
-    @asyncio.coroutine
-    def metadata(self):
+    async def metadata(self):
         path = urlparse(self.url).path
         name, ext = os.path.splitext(os.path.split(path)[-1])
         content_type, _ = mimetypes.guess_type(self.url)
         unique_key = hashlib.sha256(self.url.encode('utf-8')).hexdigest()
         return provider.ProviderMetadata(name, ext, content_type, unique_key, self.url)
 
-    @asyncio.coroutine
-    def download(self):
-        response = yield from aiohttp.request('GET', self.url)
+    async def download(self):
+        response = await aiohttp.request('GET', self.url)
         if response.status >= 400:
-            raise exceptions.ProviderError('Unable to download the requested file, please try again later.', code=response.status)
+            err_resp = await response.read()
+            logger.error('Unable to download file: ({}) {}'.format(response.status, err_resp.decode('utf-8')))
+            raise exceptions.ProviderError(
+                'Unable to download the requested file, please try again later.',
+                code=response.status
+            )
         return streams.ResponseStreamReader(response)

--- a/mfr/providers/osf/provider.py
+++ b/mfr/providers/osf/provider.py
@@ -111,4 +111,4 @@ class OsfProvider(provider.BaseProvider):
         if self.authorization:
             kwargs.setdefault('headers', {})['Authorization'] = 'Bearer ' + self.token
 
-        return (await aiohttp.request(method, url, *args, **kwargs))
+        return await aiohttp.request(method, url, *args, **kwargs)

--- a/mfr/providers/osf/provider.py
+++ b/mfr/providers/osf/provider.py
@@ -1,7 +1,7 @@
 import os
 import json
-import asyncio
 import hashlib
+import logging
 import mimetypes
 
 import furl
@@ -11,6 +11,8 @@ from waterbutler.core import streams
 
 from mfr.core import exceptions
 from mfr.core import provider
+
+logger = logging.getLogger(__name__)
 
 
 class OsfProvider(provider.BaseProvider):
@@ -32,19 +34,19 @@ class OsfProvider(provider.BaseProvider):
         if self.view_only:
             self.view_only = self.view_only[0].decode()
 
-    @asyncio.coroutine
-    def metadata(self):
-        download_url = yield from self._fetch_download_url()
+    async def metadata(self):
+        download_url = await self._fetch_download_url()
         if '/file?' in download_url:
             # TODO Remove this when API v0 is officially deprecated
             metadata_url = download_url.replace('/file?', '/data?', 1)
-            metadata_request = yield from self._make_request('GET', metadata_url)
-            metadata = yield from metadata_request.json()
+            metadata_request = await self._make_request('GET', metadata_url)
+            metadata = await metadata_request.json()
         else:
-            metadata_request = yield from self._make_request('HEAD', download_url)
+            metadata_request = await self._make_request('HEAD', download_url)
             # To make changes to current code as minimal as possible
             metadata = {'data': json.loads(metadata_request.headers['x-waterbutler-metadata'])['attributes']}
-        yield from metadata_request.release()
+        await metadata_request.release()
+
         # e.g.,
         # metadata = {'data': {
         #     'name': 'blah.png',
@@ -54,6 +56,7 @@ class OsfProvider(provider.BaseProvider):
         #         ...
         #     },
         # }}
+
         name, ext = os.path.splitext(metadata['data']['name'])
         content_type = metadata['data']['contentType'] or mimetypes.guess_type(metadata['data']['name'])[0]
         cleaned_url = furl.furl(download_url)
@@ -62,22 +65,28 @@ class OsfProvider(provider.BaseProvider):
         unique_key = hashlib.sha256((metadata['data']['etag'] + cleaned_url.url).encode('utf-8')).hexdigest()
         return provider.ProviderMetadata(name, ext, content_type, unique_key, download_url)
 
-    @asyncio.coroutine
-    def download(self):
-        download_url = yield from self._fetch_download_url()
-        response = yield from self._make_request('GET', download_url, allow_redirects=False)
+    async def download(self):
+        download_url = await self._fetch_download_url()
+        response = await self._make_request('GET', download_url, allow_redirects=False)
+
         if response.status >= 400:
-            raise exceptions.ProviderError('Unable to download the requested file, please try again later.', code=response.status)
+            err_resp = await response.read()
+            logger.error('Unable to download file: ({}) {}'.format(response.status, err_resp.decode('utf-8')))
+            raise exceptions.ProviderError(
+                'Unable to download the requested file, please try again later.',
+                code=response.status
+            )
+
         if response.status in (302, 301):
-            yield from response.release()
-            response = yield from aiohttp.request('GET', response.headers['location'])
+            await response.release()
+            response = await aiohttp.request('GET', response.headers['location'])
+
         return streams.ResponseStreamReader(response, unsizable=True)
 
-    @asyncio.coroutine
-    def _fetch_download_url(self):
+    async def _fetch_download_url(self):
         if not self.download_url:
             # make request to osf, don't follow, store waterbutler download url
-            request = yield from self._make_request(
+            request = await self._make_request(
                 'GET',
                 self.url,
                 allow_redirects=False,
@@ -85,14 +94,14 @@ class OsfProvider(provider.BaseProvider):
                     'Content-Type': 'application/json'
                 }
             )
-            yield from request.release()
+            await request.release()
+
             if request.status != 302:
                 raise exceptions.ProviderError(request.reason, request.status)
             self.download_url = request.headers['location']
         return self.download_url
 
-    @asyncio.coroutine
-    def _make_request(self, method, url, *args, **kwargs):
+    async def _make_request(self, method, url, *args, **kwargs):
         if self.cookies:
             kwargs['cookies'] = self.cookies
         if self.cookie:
@@ -102,4 +111,4 @@ class OsfProvider(provider.BaseProvider):
         if self.authorization:
             kwargs.setdefault('headers', {})['Authorization'] = 'Bearer ' + self.token
 
-        return (yield from aiohttp.request(method, url, *args, **kwargs))
+        return (await aiohttp.request(method, url, *args, **kwargs))

--- a/mfr/providers/osf/provider.py
+++ b/mfr/providers/osf/provider.py
@@ -44,6 +44,7 @@ class OsfProvider(provider.BaseProvider):
             metadata_request = yield from self._make_request('HEAD', download_url)
             # To make changes to current code as minimal as possible
             metadata = {'data': json.loads(metadata_request.headers['x-waterbutler-metadata'])['attributes']}
+        yield from metadata_request.release()
         # e.g.,
         # metadata = {'data': {
         #     'name': 'blah.png',
@@ -68,6 +69,7 @@ class OsfProvider(provider.BaseProvider):
         if response.status >= 400:
             raise exceptions.ProviderError('Unable to download the requested file, please try again later.', code=response.status)
         if response.status in (302, 301):
+            yield from response.release()
             response = yield from aiohttp.request('GET', response.headers['location'])
         return streams.ResponseStreamReader(response, unsizable=True)
 
@@ -83,6 +85,7 @@ class OsfProvider(provider.BaseProvider):
                     'Content-Type': 'application/json'
                 }
             )
+            yield from request.release()
             if request.status != 302:
                 raise exceptions.ProviderError(request.reason, request.status)
             self.download_url = request.headers['location']

--- a/mfr/server/app.py
+++ b/mfr/server/app.py
@@ -1,4 +1,3 @@
-import gc
 import asyncio
 
 import tornado.web
@@ -34,19 +33,8 @@ def make_app(debug):
     return app
 
 
-@asyncio.coroutine
-def cleanup():
-    # Forces exceptions to be garbage collected
-    # This is fixed in python 3.5 but needs manual collection in 3.4
-    while True:
-        gc.collect()
-        yield from asyncio.sleep(1)
-
-
 def serve():
     tornado.platform.asyncio.AsyncIOMainLoop().install()
-
-    asyncio.async(cleanup())
 
     app = make_app(server_settings.DEBUG)
 

--- a/mfr/server/handlers/core.py
+++ b/mfr/server/handlers/core.py
@@ -49,8 +49,7 @@ class CorsMixin(tornado.web.RequestHandler):
 
 class BaseHandler(CorsMixin, tornado.web.RequestHandler, SentryMixin):
 
-    @tornado.gen.coroutine
-    def prepare(self):
+    async def prepare(self):
         if self.request.method == 'OPTIONS':
             return
 
@@ -62,7 +61,7 @@ class BaseHandler(CorsMixin, tornado.web.RequestHandler, SentryMixin):
             self.url
         )
 
-        self.metadata = yield from self.provider.metadata()
+        self.metadata = await self.provider.metadata()
 
         self.cache_provider = waterbutler.core.utils.make_provider(
             settings.CACHE_PROVIDER_NAME,
@@ -75,10 +74,9 @@ class BaseHandler(CorsMixin, tornado.web.RequestHandler, SentryMixin):
             'filesystem', {}, {}, settings.LOCAL_CACHE_PROVIDER_SETTINGS
         )
 
-    @tornado.gen.coroutine
-    def write_stream(self, stream):
+    async def write_stream(self, stream):
         while True:
-            chunk = yield from stream.read(settings.CHUNK_SIZE)
+            chunk = await stream.read(settings.CHUNK_SIZE)
             if not chunk:
                 break
             # Temp fix, write does not accept bytearrays currently
@@ -116,8 +114,7 @@ class ExtensionsStaticFileHandler(tornado.web.StaticFileHandler, CorsMixin):
             for ep in list(pkg_resources.iter_entry_points(namespace))
         }
 
-    @tornado.gen.coroutine
-    def get(self, module_name, path):
+    async def get(self, module_name, path):
         try:
             super().initialize(self.modules[module_name])
             return (yield super().get(path))

--- a/mfr/server/handlers/core.py
+++ b/mfr/server/handlers/core.py
@@ -81,6 +81,9 @@ class BaseHandler(CorsMixin, tornado.web.RequestHandler, SentryMixin):
             chunk = yield from stream.read(settings.CHUNK_SIZE)
             if not chunk:
                 break
+            # Temp fix, write does not accept bytearrays currently
+            if isinstance(chunk, bytearray):
+                chunk = bytes(chunk)
             self.write(chunk)
             yield self.flush()
 

--- a/mfr/server/handlers/core.py
+++ b/mfr/server/handlers/core.py
@@ -123,12 +123,12 @@ class ExtensionsStaticFileHandler(tornado.web.StaticFileHandler, CorsMixin):
     async def get(self, module_name, path):
         try:
             super().initialize(self.modules[module_name])
-            return (await super().get(path))
+            return await super().get(path)
         except Exception:
             self.set_status(404)
 
         try:
             super().initialize(settings.STATIC_PATH)
-            return (await super().get(path))
+            return await super().get(path)
         except Exception:
             self.set_status(404)

--- a/mfr/server/handlers/export.py
+++ b/mfr/server/handlers/export.py
@@ -3,8 +3,6 @@ import uuid
 import asyncio
 import logging
 
-import tornado.gen
-
 import waterbutler.core.streams
 import waterbutler.core.exceptions
 
@@ -19,25 +17,23 @@ class ExportHandler(core.BaseHandler):
 
     ALLOWED_METHODS = ['GET']
 
-    @tornado.gen.coroutine
-    def prepare(self):
+    async def prepare(self):
         if self.request.method not in self.ALLOWED_METHODS:
             return
 
         yield super().prepare()
 
         self.format = self.request.query_arguments['format'][0].decode('utf-8')
-        self.cache_file_path = yield from self.cache_provider.validate_path('/export/{}.{}'.format(self.metadata.unique_key, self.format))
-        self.source_file_path = yield from self.local_cache_provider.validate_path('/export/{}'.format(uuid.uuid4()))
-        self.output_file_path = yield from self.local_cache_provider.validate_path('/export/{}.{}'.format(self.source_file_path.name, self.format))
+        self.cache_file_path = await self.cache_provider.validate_path('/export/{}.{}'.format(self.metadata.unique_key, self.format))
+        self.source_file_path = await self.local_cache_provider.validate_path('/export/{}'.format(uuid.uuid4()))
+        self.output_file_path = await self.local_cache_provider.validate_path('/export/{}.{}'.format(self.source_file_path.name, self.format))
 
-    @tornado.gen.coroutine
-    def get(self):
+    async def get(self):
         """Export a file to the format specified via the associated extension library"""
 
         if settings.CACHE_ENABLED:
             try:
-                cached_stream = yield from self.cache_provider.download(self.cache_file_path)
+                cached_stream = await self.cache_provider.download(self.cache_file_path)
             except waterbutler.core.exceptions.DownloadError as e:
                 assert e.code == 404, 'Non-404 DownloadError {!r}'.format(e)
                 logger.info('No cached file found; Starting export [{}]'.format(self.cache_file_path))
@@ -46,8 +42,8 @@ class ExportHandler(core.BaseHandler):
                 self._set_headers()
                 return (yield self.write_stream(cached_stream))
 
-        yield from self.local_cache_provider.upload(
-            (yield from self.provider.download()),
+        await self.local_cache_provider.upload(
+            (await self.provider.download()),
             self.source_file_path
         )
 
@@ -59,20 +55,19 @@ class ExportHandler(core.BaseHandler):
         )
 
         loop = asyncio.get_event_loop()
-        yield from loop.run_in_executor(None, exporter.export)
+        await loop.run_in_executor(None, exporter.export)
 
         with open(self.output_file_path.full_path, 'rb') as fp:
             self._set_headers()
             yield self.write_stream(waterbutler.core.streams.FileStreamReader(fp))
 
-    @tornado.gen.coroutine
-    def on_finish(self):
+    async def on_finish(self):
         if self.request.method not in self.ALLOWED_METHODS:
             return
 
         if settings.CACHE_ENABLED and os.path.exists(self.output_file_path.full_path):
             with open(self.output_file_path.full_path, 'rb') as fp:
-                yield from self.cache_provider.upload(waterbutler.core.streams.FileStreamReader(fp), self.cache_file_path)
+                await self.cache_provider.upload(waterbutler.core.streams.FileStreamReader(fp), self.cache_file_path)
 
         if hasattr(self, 'source_file_path'):
             try:

--- a/mfr/server/handlers/export.py
+++ b/mfr/server/handlers/export.py
@@ -40,10 +40,10 @@ class ExportHandler(core.BaseHandler):
             else:
                 logger.info('Cached file found; Sending downstream [{}]'.format(self.cache_file_path))
                 self._set_headers()
-                return (await self.write_stream(cached_stream))
+                return await self.write_stream(cached_stream)
 
         await self.local_cache_provider.upload(
-            (await self.provider.download()),
+            await self.provider.download(),
             self.source_file_path
         )
 

--- a/mfr/server/handlers/export.py
+++ b/mfr/server/handlers/export.py
@@ -65,12 +65,7 @@ class ExportHandler(core.BaseHandler):
         if self.request.method not in self.ALLOWED_METHODS:
             return
 
-        # Spin off upload into non-blocking operation
-        loop = asyncio.get_event_loop()
-        loop.call_soon(
-            asyncio.ensure_future,
-            self._cache_and_clean(),
-        )
+        asyncio.ensure_future(self._cache_and_clean())
 
     async def _cache_and_clean(self):
         if settings.CACHE_ENABLED and os.path.exists(self.output_file_path.full_path):

--- a/mfr/server/handlers/render.py
+++ b/mfr/server/handlers/render.py
@@ -58,9 +58,11 @@ class RenderHandler(core.BaseHandler):
 
         # Spin off upload into non-blocking operation
         if renderer.cache_result and settings.CACHE_ENABLED:
-            loop.call_soon(
-                asyncio.ensure_future,
-                self.cache_provider.upload(waterbutler.core.streams.StringStream(rendition), self.cache_file_path)
+            asyncio.ensure_future(
+                self.cache_provider.upload(
+                    waterbutler.core.streams.StringStream(rendition),
+                    self.cache_file_path
+                )
             )
 
         await self.write_stream(waterbutler.core.streams.StringStream(rendition))

--- a/mfr/server/handlers/render.py
+++ b/mfr/server/handlers/render.py
@@ -45,16 +45,16 @@ class RenderHandler(core.BaseHandler):
                 logger.info('No cached file found; Starting render [{}]'.format(self.cache_file_path))
             else:
                 logger.info('Cached file found; Sending downstream [{}]'.format(self.cache_file_path))
-                return (await self.write_stream(cached_stream))
+                return await self.write_stream(cached_stream)
 
         if renderer.file_required:
             await self.local_cache_provider.upload(
-                (await self.provider.download()),
+                await self.provider.download(),
                 self.source_file_path
             )
 
         loop = asyncio.get_event_loop()
-        rendition = (await loop.run_in_executor(None, renderer.render))
+        rendition = await loop.run_in_executor(None, renderer.render)
 
         # Spin off upload into non-blocking operation
         if renderer.cache_result and settings.CACHE_ENABLED:

--- a/mfr/server/handlers/render.py
+++ b/mfr/server/handlers/render.py
@@ -21,7 +21,7 @@ class RenderHandler(core.BaseHandler):
         if self.request.method not in self.ALLOWED_METHODS:
             return
 
-        yield super().prepare()
+        await super().prepare()
 
         self.cache_file_path = await self.cache_provider.validate_path('/render/' + self.metadata.unique_key)
         self.source_file_path = await self.local_cache_provider.validate_path('/render/' + str(uuid.uuid4()))
@@ -45,7 +45,7 @@ class RenderHandler(core.BaseHandler):
                 logger.info('No cached file found; Starting render [{}]'.format(self.cache_file_path))
             else:
                 logger.info('Cached file found; Sending downstream [{}]'.format(self.cache_file_path))
-                return (yield self.write_stream(cached_stream))
+                return (await self.write_stream(cached_stream))
 
         if renderer.file_required:
             await self.local_cache_provider.upload(
@@ -63,9 +63,9 @@ class RenderHandler(core.BaseHandler):
                 self.cache_provider.upload(waterbutler.core.streams.StringStream(rendition), self.cache_file_path)
             )
 
-        yield self.write_stream(waterbutler.core.streams.StringStream(rendition))
+        await self.write_stream(waterbutler.core.streams.StringStream(rendition))
 
-    async def on_finish(self):
+    def on_finish(self):
         if self.request.method not in self.ALLOWED_METHODS:
             return
 

--- a/mfr/server/settings.py
+++ b/mfr/server/settings.py
@@ -16,7 +16,7 @@ STATIC_PATH = config.get('STATIC_PATH', os.path.join(os.path.dirname(__file__), 
 ADDRESS = config.get('ADDRESS', '127.0.0.1')
 PORT = config.get('PORT', 7778)
 
-DEBUG = config.get('DEBUG', True)
+DEBUG = config.get('DEBUG', False)
 
 SSL_CERT_FILE = config.get('SSL_CERT_FILE', None)
 SSL_KEY_FILE = config.get('SSL_KEY_FILE', None)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,8 @@ stevedore==1.2.0
 tornado==4.3
 
 # WaterButler
-git+https://github.com/CenterForOpenScience/waterbutler.git@0.18.2
+git+https://github.com/CenterForOpenScience/waterbutler.git@0.19.0#egg=waterbutler
+agent==0.1.2
 
 # CodePygments
 Pygments==2.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-mako==1.0.1
 aiohttp==0.18.4
-raven==5.10.2
 furl==0.4.2
+mako==1.0.1
+raven==5.10.2
 stevedore==1.2.0
 tornado==4.3
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,11 +32,11 @@ mistune==0.7
 docutils==0.12
 
 # Tabular
-pandas==0.16.1
+pandas==0.17.1
 git+https://github.com/icereval/xlrd.git
 
 # Rpy
-rpy2==2.6.2
+rpy2==2.7.8
 
 #Md
 markdown==2.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 mako==1.0.1
-aiohttp==0.14.1
+aiohttp==0.18.4
 raven==5.10.2
 furl==0.4.2
 stevedore==1.2.0
-tornado==4.2
+tornado==4.3
 
 # WaterButler
 git+https://github.com/CenterForOpenScience/waterbutler.git@0.18.2

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,8 +1,5 @@
 import pytest
-import asyncio
 from unittest import mock
-
-from decorator import decorator
 
 from tornado import testing
 from tornado.platform.asyncio import AsyncIOMainLoop
@@ -12,18 +9,13 @@ from mfr.core.provider import BaseProvider
 
 
 class MockCoroutine(mock.Mock):
-    @asyncio.coroutine
-    def __call__(self, *args, **kwargs):
+    async def __call__(self, *args, **kwargs):
         return super().__call__(*args, **kwargs)
-
-@decorator
-def async(func, *args, **kwargs):
-    future = func(*args, **kwargs)
-    asyncio.get_event_loop().run_until_complete(future)
 
 
 class FakeProvider(BaseProvider):
     pass
+
 
 class HandlerTestCase(testing.AsyncHTTPTestCase):
 


### PR DESCRIPTION
Continuing @chrisseto's work, finish the 3.5 conversion of MFR.

Notes:
* 3.5-based MFR will only work with a 3.5-based WB, so the WB dep has been bumped to v0.19.0.
* The server `DEBUG` must be set to False because of [this bug in core python](https://bugs.python.org/issue25394).  The default has been updated to False, so you should only need to change anything if you have set it in `~/.cos/mfr-test.json`.
* `pandas` and `rpy2` were bumped to take advantage of upstream 3.5 fixes.
* a couple of hacks needed for 3.4 were removed.

Fixes: [#OSF-6143]