### PR TITLE
Sort stringified numbers as numbers, not strings

### DIFF
--- a/mfr/extensions/tabular/templates/viewer.mako
+++ b/mfr/extensions/tabular/templates/viewer.mako
@@ -91,6 +91,15 @@
             return filteredData;
         }
 
+        function prepareSortValue(s) {
+            // Everything retrieved from SlickGrid is a string.
+            // If those strings are numbers, parse them.
+            if (! isNaN (s-0) && s !== null && s !== "" && s !== false) {
+                return parseFloat(s);
+            }
+            return s;
+        }
+
         function sortData (e, args) {
             var cols = args.sortCols;
             var rows = grid.getData();
@@ -98,7 +107,7 @@
                 for (var i = 0; i < cols.length; i++) {
                     var field = cols[i].sortCol.field;
                     var sign = cols[i].sortAsc ? 1 : -1;
-                    var value1 = dataRow1[field], value2 = dataRow2[field];
+                    var value1 = prepareSortValue(dataRow1[field]), value2 = prepareSortValue(dataRow2[field]);
                     var result = (value1 == value2 ? 0 : (value1 > value2 ? 1 : -1)) * sign;
                     if (result !== 0) {
                         return result;
@@ -113,7 +122,7 @@
         function reAdjust(){
             liFirstPosLeft = $('.list li:first').position().left;
             liLastPosRight = $('.list li:last').position().left + $('.list li:last').width();
-            widthOfList = $('.list').width()
+            widthOfList = $('.list').width();
             if (liFirstPosLeft < 0) {
                 $('.scroller-left').show();
             }


### PR DESCRIPTION
Purpose
=======
The compare function that sorts tabular data should but does not compare stringified numbers properly.

<img width="503" alt="screen shot 2016-05-11 at 10 54 03" src="https://cloud.githubusercontent.com/assets/5659262/15185495/7d532e54-1767-11e6-8cff-344614a95b5d.png">


Changes
=======
* If values to be compared are numbers, parse them as such. Otherwise, use default string ordering.

<img width="525" alt="screen shot 2016-05-11 at 10 55 24" src="https://cloud.githubusercontent.com/assets/5659262/15185507/8a1fb152-1767-11e6-9444-f6100d536b49.png">


Side Effects
==========
Columns populated with both strings and numbers still behave oddly, but it's no worse than before.

<img width="278" alt="screen shot 2016-05-11 at 11 00 32" src="https://cloud.githubusercontent.com/assets/5659262/15185543/b818cb48-1767-11e6-96ee-0159e2a199ad.png">
<img width="279" alt="screen shot 2016-05-11 at 11 00 39" src="https://cloud.githubusercontent.com/assets/5659262/15185544/b81f077e-1767-11e6-90ae-971197f0f21b.png">
<img width="317" alt="screen shot 2016-05-11 at 11 00 52" src="https://cloud.githubusercontent.com/assets/5659262/15185545/b8204904-1767-11e6-9d13-a49c04383352.png">
<img width="268" alt="screen shot 2016-05-11 at 11 01 00" src="https://cloud.githubusercontent.com/assets/5659262/15185546/b820412a-1767-11e6-9504-f793948a8a3d.png">
