### PR TITLE
Line wrap [OSF-5875]

### DIFF
--- a/mfr/extensions/codepygments/static/css/default.css
+++ b/mfr/extensions/codepygments/static/css/default.css
@@ -82,11 +82,12 @@ code, kbd, pre, samp {
     box-sizing: border-box;
 }
 
-/* CSS only for Firefox */
+/* CSS only for Firefox
 @-moz-document url-prefix() {
   .highlight > pre {
-      white-space: pre-wrap;       /*  css-3 */
-      white-space: -moz-pre-wrap;  /* Mozilla, since 1999 */
+      white-space: pre-wrap;
+      white-space: -moz-pre-wrap;
       word-break: break-all;
   }
 }
+*/

--- a/mfr/extensions/codepygments/static/css/default.css
+++ b/mfr/extensions/codepygments/static/css/default.css
@@ -71,7 +71,7 @@ pre {
     line-height: 1.42857;
     background-color: #F5F5F5;
     border: 1px solid #CCC;
-    white-space:pre-line;
+    white-space: pre-line;
 }
 
 code, kbd, pre, samp {
@@ -81,13 +81,3 @@ code, kbd, pre, samp {
 * {
     box-sizing: border-box;
 }
-
-/* CSS only for Firefox
-@-moz-document url-prefix() {
-  .highlight > pre {
-      white-space: pre-wrap;
-      white-space: -moz-pre-wrap;
-      word-break: break-all;
-  }
-}
-*/

--- a/mfr/extensions/codepygments/static/css/default.css
+++ b/mfr/extensions/codepygments/static/css/default.css
@@ -71,7 +71,7 @@ pre {
     line-height: 1.42857;
     background-color: #F5F5F5;
     border: 1px solid #CCC;
-    white-space: pre-line;
+    white-space: pre-wrap;
 }
 
 code, kbd, pre, samp {

--- a/mfr/extensions/codepygments/static/css/default.css
+++ b/mfr/extensions/codepygments/static/css/default.css
@@ -71,6 +71,7 @@ pre {
     line-height: 1.42857;
     background-color: #F5F5F5;
     border: 1px solid #CCC;
+    white-space:pre-line;
 }
 
 code, kbd, pre, samp {


### PR DESCRIPTION
## Purpose

When a .txt file is uploaded in Safari, the line overflow will wrap around when rendered there, but the same file will have to scroll to the right in Chrome.

![image](https://cloud.githubusercontent.com/assets/15851093/15365845/ce4f38f6-1cef-11e6-80e6-1dcc16c5de04.png)

## Similar problems

Firefox also had this problem [OSF-3532] and it was resolved with a Firefox-specific line in the CSS.

## Changes

Added a line to the CSS in mfr/extensions/codepygements/static/css/default.css for the pre element:

`  white-space : pre-line;   ` 

so it wraps to the next line now.

![image](https://cloud.githubusercontent.com/assets/15851093/15365993/5ffda170-1cf0-11e6-9e76-200c98a4ef73.png)

Removed Firefox-specific code to support Chrome as well.

## Side Effects
- Safari: Words no longer break to wrap in the middle of the word
- Firefox: Words no longer break to wrap in the middle of the word
- CSS simplification