### PR TITLE
Feature/Handle case when waterbutler v1 url provided.

### DIFF
--- a/mfr/providers/osf/provider.py
+++ b/mfr/providers/osf/provider.py
@@ -84,7 +84,7 @@ class OsfProvider(provider.BaseProvider):
         return streams.ResponseStreamReader(response, unsizable=True)
 
     async def _fetch_download_url(self):
-        # Waterbutler url provided
+        # v1 Waterbutler url provided
         if 'v1/resources' in self.url:
             return self.url
         if not self.download_url:

--- a/mfr/providers/osf/provider.py
+++ b/mfr/providers/osf/provider.py
@@ -2,6 +2,7 @@ import os
 import json
 import hashlib
 import logging
+from urllib.parse import urlparse
 import mimetypes
 
 import furl
@@ -85,7 +86,8 @@ class OsfProvider(provider.BaseProvider):
 
     async def _fetch_download_url(self):
         # v1 Waterbutler url provided
-        if 'v1/resources' in self.url:
+        path = urlparse(self.url).path
+        if path.startswith('/v1/resources'):
             return self.url
         if not self.download_url:
             # make request to osf, don't follow, store waterbutler download url

--- a/mfr/providers/osf/provider.py
+++ b/mfr/providers/osf/provider.py
@@ -84,6 +84,9 @@ class OsfProvider(provider.BaseProvider):
         return streams.ResponseStreamReader(response, unsizable=True)
 
     async def _fetch_download_url(self):
+        # Waterbutler url provided
+        if 'v1/resources' in self.url:
+            return self.url
         if not self.download_url:
             # make request to osf, don't follow, store waterbutler download url
             request = await self._make_request(

--- a/mfr/server/settings.py
+++ b/mfr/server/settings.py
@@ -36,7 +36,7 @@ CACHE_PROVIDER_CREDENTIALS = config.get('CACHE_PROVIDER_CREDENTIALS', {})
 
 LOCAL_CACHE_PROVIDER_SETTINGS = config.get('LOCAL_CACHE_PROVIDER_SETTINGS', {'folder': '/tmp/mfrlocalcache/'})
 
-ALLOWED_PROVIDER_DOMAINS = config.get('ALLOWED_PROVIDER_DOMAINS', ['http://localhost:5000/'])
+ALLOWED_PROVIDER_DOMAINS = config.get('ALLOWED_PROVIDER_DOMAINS', ['http://localhost:5000/', 'http://localhost:7777/'])
 ALLOWED_PROVIDER_NETLOCS = []
 for domain in ALLOWED_PROVIDER_DOMAINS:
     ALLOWED_PROVIDER_NETLOCS.append(furl.furl(domain).netloc)


### PR DESCRIPTION
Needed for https://openscience.atlassian.net/browse/EOSF-19

# Purpose

MFR was written before APIv2.   If you give it a url with a file GUID in it, it then attempts to fetch the download url.  However, the APIv2 already returns a download url for a file. 

# Changes
Handle the case when the download url is passed directly to MFR.