### PR TITLE
Fix presentation mode not working with correct fullscreen request name

### DIFF
--- a/mfr/extensions/pdf/static/web/viewer.js
+++ b/mfr/extensions/pdf/static/web/viewer.js
@@ -1969,8 +1969,8 @@ var PresentationMode = {
       this.container.requestFullscreen();
     } else if (this.container.mozRequestFullScreen) {
       this.container.mozRequestFullScreen();
-    } else if (this.container.webkitRequestFullScreen) {
-      this.container.webkitRequestFullScreen(Element.ALLOW_KEYBOARD_INPUT);
+    } else if (this.container.webkitRequestFullscreen) {
+      this.container.webkitRequestFullscreen(Element.ALLOW_KEYBOARD_INPUT);
     } else if (this.container.msRequestFullscreen) {
       this.container.msRequestFullscreen();
     } else {


### PR DESCRIPTION
## Purpose:

The fullscreen/presentation mode button does not work in Safari. This PR fixes that by correcting the webkit fullscreen request name.

## Changes:

Changed `webkitRequestFullScreen`  to `webkitRequestFullscreen` ('s' in screen is not supposed to be capitalized).

## Side effects:

None visible.

## Ticket:
[https://openscience.atlassian.net/browse/OSF-7030](https://openscience.atlassian.net/browse/OSF-7030)