### PR TITLE
[Feature] Environment Variable Settings Support

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,13 +2,10 @@
 
 -e git+https://github.com/centerforopenscience/aiohttpretty.git@0.0.2#egg=aiohttpretty
 colorlog==2.5.0
-flake8==2.3.0
+flake8==3.0.4
 ipdb
 mccabe
-pep8
 pyflakes
 pytest==2.8.2
 pytest-cov==2.2.0
 pyzmq==14.4.1
-
-

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,6 +5,7 @@ colorlog==2.5.0
 flake8==3.0.4
 ipdb
 mccabe
+pydevd==0.0.6
 pyflakes
 pytest==2.8.2
 pytest-cov==2.2.0

--- a/mfr/extensions/image/settings.py
+++ b/mfr/extensions/image/settings.py
@@ -1,9 +1,6 @@
-try:
-    from mfr import settings
-except ImportError:
-    settings = {}
+from mfr import settings
 
-config = settings.get('IMAGE_EXTENSION_CONFIG', {})
+config = settings.child('IMAGE_EXTENSION_CONFIG')
 
 EXPORT_TYPE = config.get('EXPORT_TYPE', 'jpeg')
 EXPORT_MAXIMUM_SIZE = config.get('EXPORT_MAXIMUM_SIZE', '1200x1200')

--- a/mfr/extensions/pdb/settings.py
+++ b/mfr/extensions/pdb/settings.py
@@ -1,10 +1,6 @@
-try:
-    from mfr import settings
-except ImportError:
-    settings = {}
+from mfr import settings
 
-config = settings.get('PDB_EXTENSION_CONFIG', {})
-
+config = settings.child('PDB_EXTENSION_CONFIG')
 
 OPTIONS = config.get('OPTIONS', {
     'width': 'auto',

--- a/mfr/extensions/tabular/settings.py
+++ b/mfr/extensions/tabular/settings.py
@@ -1,13 +1,7 @@
+from mfr import settings
 from mfr.extensions.tabular import libs
 
-
-try:
-    from mfr import settings
-except ImportError:
-    settings = {}
-
-config = settings.get('TABULAR_EXTENSION_CONFIG', {})
-
+config = settings.child('TABULAR_EXTENSION_CONFIG')
 
 MAX_SIZE = config.get('MAX_SIZE', 10000)
 TABLE_WIDTH = config.get('TABLE_WIDTH', 700)

--- a/mfr/extensions/unoconv/settings.py
+++ b/mfr/extensions/unoconv/settings.py
@@ -1,11 +1,8 @@
 import os
 
-try:
-    from mfr import settings
-except ImportError:
-    settings = {}
+from mfr import settings
 
-config = settings.get('UNOCONV_EXTENSION_CONFIG', {})
+config = settings.child('UNOCONV_EXTENSION_CONFIG')
 
 UNOCONV_BIN = config.get('UNOCONV_BIN', '/usr/bin/unoconv')
 

--- a/mfr/providers/http/settings.py
+++ b/mfr/providers/http/settings.py
@@ -1,6 +1,3 @@
-try:
-    from mfr import settings
-except ImportError:
-    settings = {}
+from mfr import settings
 
-config = settings.get('HTTP_PROVIDER_CONFIG', {})
+config = settings.child('HTTP_PROVIDER_CONFIG')

--- a/mfr/providers/osf/settings.py
+++ b/mfr/providers/osf/settings.py
@@ -1,10 +1,6 @@
-try:
-    from mfr import settings
-except ImportError:
-    settings = {}
+from mfr import settings
 
-config = settings.get('OSF_PROVIDER_CONFIG', {})
-
+config = settings.child('OSF_PROVIDER_CONFIG')
 
 # BASE_URL = config.get('BASE_URL', 'http://localhost:5001/')
 

--- a/mfr/server/settings.py
+++ b/mfr/server/settings.py
@@ -32,7 +32,7 @@ CACHE_PROVIDER_CREDENTIALS = config.get('CACHE_PROVIDER_CREDENTIALS', {})
 
 LOCAL_CACHE_PROVIDER_SETTINGS = config.get('LOCAL_CACHE_PROVIDER_SETTINGS', {'folder': '/tmp/mfrlocalcache/'})
 
-ALLOWED_PROVIDER_DOMAINS = config.get('ALLOWED_PROVIDER_DOMAINS', ['http://localhost:5000/', 'http://localhost:7777/'])
+ALLOWED_PROVIDER_DOMAINS = config.get('ALLOWED_PROVIDER_DOMAINS', 'http://localhost:5000/ http://localhost:7777/').split(' ')
 ALLOWED_PROVIDER_NETLOCS = []
 for domain in ALLOWED_PROVIDER_DOMAINS:
     ALLOWED_PROVIDER_NETLOCS.append(furl.furl(domain).netloc)

--- a/mfr/server/settings.py
+++ b/mfr/server/settings.py
@@ -3,13 +3,9 @@ import os
 import furl
 
 
-try:
-    from mfr import settings
-except ImportError:
-    settings = {}
+from mfr import settings
 
-config = settings.get('SERVER_CONFIG', {})
-
+config = settings.child('SERVER_CONFIG')
 
 STATIC_PATH = config.get('STATIC_PATH', os.path.join(os.path.dirname(__file__), 'static'))
 
@@ -42,16 +38,16 @@ for domain in ALLOWED_PROVIDER_DOMAINS:
     ALLOWED_PROVIDER_NETLOCS.append(furl.furl(domain).netloc)
 
 
-analytics_config = config.get('ANALYTICS', {})
+analytics_config = config.child('ANALYTICS')
 
-keen_config = analytics_config.get('KEEN', {})
+keen_config = analytics_config.child('KEEN')
 KEEN_API_BASE_URL = keen_config.get('API_BASE_URL', 'https://api.keen.io')
 KEEN_API_VERSION = keen_config.get('API_VERSION', '3.0')
 
-keen_private_config = keen_config.get('PRIVATE', {})
+keen_private_config = keen_config.child('PRIVATE')
 KEEN_PRIVATE_PROJECT_ID = keen_private_config.get('PROJECT_ID', None)
 KEEN_PRIVATE_WRITE_KEY = keen_private_config.get('WRITE_KEY', None)
 
-keen_public_config = keen_config.get('PUBLIC', {})
+keen_public_config = keen_config.child('PUBLIC')
 KEEN_PUBLIC_PROJECT_ID = keen_public_config.get('PROJECT_ID', None)
 KEEN_PUBLIC_WRITE_KEY = keen_public_config.get('WRITE_KEY', None)

--- a/tasks.py
+++ b/tasks.py
@@ -59,5 +59,12 @@ def test(verbose=False):
 @task
 def server():
     monkey_patch()
+
+    if os.environ.get('REMOTE_DEBUG', None):
+        import pydevd
+        # e.g. '127.0.0.1:5678'
+        remote_parts = os.environ.get('REMOTE_DEBUG').split(':')
+        pydevd.settrace(remote_parts[0], port=int(remote_parts[1]), suspend=False, stdoutToServer=True, stderrToServer=True)
+
     from mfr.server.app import serve
     serve()


### PR DESCRIPTION
Support for settings overrides w/ Environment Variables for simple values.

[Twelve-Factor App Config](https://12factor.net/config)

Discovered need when simplifying docker-compose integration w/ OSF.

#### Deployment Considerations
- [ ] SERVER_CONFIG  -> ALLOWED_PROVIDER_DOMAINS changed from a List to Literal String of space separated domains.

  e.g. `'http://localhost:5000/ http://localhost:7777/'`