### PR TITLE
Stuff error message to prevent IE from consuming it

### DIFF
--- a/mfr/core/exceptions.py
+++ b/mfr/core/exceptions.py
@@ -10,6 +10,8 @@ class PluginError(waterbutler.core.exceptions.PluginError):
         return '''
             <link rel="stylesheet" href="/static/css/bootstrap.min.css">
             <div class="alert alert-warning" role="alert">{}</div>
+            <div style="display: none;">This text and the text below is only presented because IE consumes error messages below 512 bytes</div>
+            <div style="display: none;">Want to help save science? Want to get paid to develop free, open source software? Check out our openings!</div>
             '''.format(self.message)
 
 


### PR DESCRIPTION
## Purpose
Internet explorer consumes error messages that are smaller than 512 bytes

## Changes

This PR stuffs the error message to be slightly larger, preventing IE from throwing its custom 404 page error.

## Side Effects
None.

## Jira Ticket
https://openscience.atlassian.net/browse/OSF-7040