### PR TITLE
[WIP][OSF-7177] MFR errors to keen.io

### DIFF
--- a/mfr/core/exceptions.py
+++ b/mfr/core/exceptions.py
@@ -1,5 +1,4 @@
 import waterbutler.core.exceptions
-from mfr.server import settings
 
 
 class PluginError(waterbutler.core.exceptions.PluginError):
@@ -7,10 +6,10 @@ class PluginError(waterbutler.core.exceptions.PluginError):
     should inherit from PluginError
     """
 
-    def __init__(self, message, code=500, keen_data={}):
+    def __init__(self, message, nomen: str, code=500):
         super().__init__(message, code)
-        if settings.KEEN_ERRORS_PROJECT_ID:
-            self.data = {self.__class__.__name__: keen_data}
+        self.nomen = nomen
+        self.data = self.keen_data
 
     def as_html(self):
         return '''
@@ -27,12 +26,27 @@ class ExtensionError(PluginError):
     inherit from ExtensionError
     """
 
+    def __init__(self, message, nomen: str, extension: str, code=500):
+        self.keen_data = {'nomen': nomen,
+                          'extension': extension,
+                          'extention_{}'.format(nomen): self.keen_data
+                          }
+        super().__init__(message, 'extension', code=code)
+
 
 class RendererError(ExtensionError):
     """The MFR related errors raised
     from a :class:`mfr.core.extension` and relating
     to rendering should inherit from RendererError
     """
+
+    def __init__(self, message, nomen: str, renderer_class: str,
+                 extension: str, code=500):
+        self.keen_data = {'nomen': nomen,
+                          'renderer_class': renderer_class,
+                          'renderer_{}'.format(nomen): self.keen_data
+                          }
+        super().__init__(message, 'renderer', extension, code=code)
 
 
 class MakeRendererError(ExtensionError):
@@ -41,11 +55,21 @@ class MakeRendererError(ExtensionError):
     should inherit from MakeRendererError
     """
 
+
 class ExporterError(ExtensionError):
     """The MFR related errors raised
     from a :class:`mfr.core.extension` and relating
     to exporting should inherit from ExporterError
     """
+
+    def __init__(self, message, nomen: str, exporter_class: str,
+                 extension: str, code=500):
+        self.keen_data = {'nomen': nomen,
+                          'exporter_class': exporter_class,
+                          'expoorter_{}'.format(nomen): self.keen_data
+                          }
+        super().__init__(message, 'exporter', extension, code=code)
+
 
 class SubprocessError(ExporterError):
     """The MFR related errors raised
@@ -53,11 +77,13 @@ class SubprocessError(ExporterError):
     to subprocess should inherit from SubprocessError
     """
 
+
 class MakeExporterError(ExtensionError):
     """The MFR related errors raised
     from a :def:`mfr.core.utils.make_exporter`
     should inherit from MakeExporterError
     """
+
 
 class ProviderError(PluginError):
     """The MFR related errors raised

--- a/mfr/core/exceptions.py
+++ b/mfr/core/exceptions.py
@@ -10,7 +10,7 @@ class PluginError(waterbutler.core.exceptions.PluginError):
     def __init__(self, message, code=500, keen_data={}):
         super().__init__(message, code)
         if settings.KEEN_ERRORS_PROJECT_ID:
-            self.data = keen_data
+            self.data = {self.__class__.__name__: keen_data}
 
     def as_html(self):
         return '''
@@ -27,18 +27,12 @@ class ExtensionError(PluginError):
     inherit from ExtensionError
     """
 
-    def __init__(self, message, code=500, keen_data={}):
-        super().__init__(message, code, keen_data=keen_data)
-
 
 class RendererError(ExtensionError):
     """The MFR related errors raised
     from a :class:`mfr.core.extension` and relating
     to rendering should inherit from RendererError
     """
-
-    def __init__(self, message, code=500, keen_data={}):
-        super().__init__(message, code, keen_data=keen_data)
 
 
 class MakeRendererError(ExtensionError):
@@ -47,14 +41,16 @@ class MakeRendererError(ExtensionError):
     should inherit from MakeRendererError
     """
 
-    def __init__(self, message, code=500, keen_data={}):
-        super().__init__(message, code, keen_data=keen_data)
-
-
 class ExporterError(ExtensionError):
     """The MFR related errors raised
     from a :class:`mfr.core.extension` and relating
     to exporting should inherit from ExporterError
+    """
+
+class SubprocessError(ExporterError):
+    """The MFR related errors raised
+    from a :class:`mfr.core.extension` and relating
+    to subprocess should inherit from SubprocessError
     """
 
 class MakeExporterError(ExtensionError):
@@ -62,10 +58,6 @@ class MakeExporterError(ExtensionError):
     from a :def:`mfr.core.utils.make_exporter`
     should inherit from MakeExporterError
     """
-
-    def __init__(self, message, code=500, keen_data={}):
-        super().__init__(message, code, keen_data=keen_data)
-
 
 class ProviderError(PluginError):
     """The MFR related errors raised
@@ -80,17 +72,9 @@ class DownloadError(ProviderError):
     to downloads should inherit from DownloadError
     """
 
-    def __init__(self, message, keen_data: dict ={}, code=500):
-        keen_data = {'DownloadError': keen_data}
-        super().__init__(message, code, keen_data=keen_data)
-
 
 class MetadataError(ProviderError):
     """The MFR related errors raised
     from a :class:`mfr.core.provider` and relating
     to metadata should inherit from MetadataError
     """
-
-    def __init__(self, message, keen_data: dict ={}, code=500):
-        keen_data = {'MetadataError': keen_data}
-        super().__init__(message, code, keen_data=keen_data)

--- a/mfr/core/exceptions.py
+++ b/mfr/core/exceptions.py
@@ -55,6 +55,10 @@ class MakeRendererError(ExtensionError):
     should inherit from MakeRendererError
     """
 
+    def __init__(self, message, driver_args: dict, extension: str, code=500):
+        self.keen_data = {'driver_args': driver_args}
+        super().__init__(message, 'make_renderer', extension, code=code)
+
 
 class ExporterError(ExtensionError):
     """The MFR related errors raised
@@ -66,7 +70,7 @@ class ExporterError(ExtensionError):
                  extension: str, code=500):
         self.keen_data = {'nomen': nomen,
                           'exporter_class': exporter_class,
-                          'expoorter_{}'.format(nomen): self.keen_data
+                          'exporter_{}'.format(nomen): self.keen_data
                           }
         super().__init__(message, 'exporter', extension, code=code)
 
@@ -77,12 +81,30 @@ class SubprocessError(ExporterError):
     to subprocess should inherit from SubprocessError
     """
 
+    def __init__(self, message, type: str, cmd: str, returncode: int,
+                 path: str, extension: str, exporter_class: str='',
+                 code: int=500):
+        self.keen_data = {'type': type,
+                          'cmd': cmd,
+                          'returncode': returncode,
+                          'path': path}
+        if exporter_class:
+            super().__init__(message, 'subprocess', exporter_class, extension,
+                             code=code)
+        else:
+            super(ExporterError, self).__init__(message, 'subprocess',
+                                                 extension, code=code)
+
 
 class MakeExporterError(ExtensionError):
     """The MFR related errors raised
     from a :def:`mfr.core.utils.make_exporter`
     should inherit from MakeExporterError
     """
+
+    def __init__(self, message, driver_args: dict, extension: str, code=500):
+        self.keen_data = {'driver_args': driver_args}
+        super().__init__(message, 'make_exporter', extension, code=code)
 
 
 class ProviderError(PluginError):
@@ -91,6 +113,13 @@ class ProviderError(PluginError):
     inherit from ProviderError
     """
 
+    def __init__(self, message, nomen: str, provider: str, code=500):
+        self.keen_data = {'nomen': nomen,
+                          'provider': provider,
+                          'provider_{}'.format(nomen): self.keen_data
+                          }
+        super().__init__(message, 'provider', code=code)
+
 
 class DownloadError(ProviderError):
     """The MFR related errors raised
@@ -98,9 +127,21 @@ class DownloadError(ProviderError):
     to downloads should inherit from DownloadError
     """
 
+    def __init__(self, message, download_url: str, response: str,
+                 provider: str, code=500):
+        self.keen_data = {'download_url': download_url,
+                          'response': response}
+        super().__init__(message, 'download', provider, code=code)
+
 
 class MetadataError(ProviderError):
     """The MFR related errors raised
     from a :class:`mfr.core.provider` and relating
     to metadata should inherit from MetadataError
     """
+
+    def __init__(self, message, metadata_url: str, response: str,
+                 provider: str, code=500):
+        self.keen_data = {'metadata_url': metadata_url,
+                          'response': response}
+        super().__init__(message, 'metadata', provider, code=code)

--- a/mfr/core/exceptions.py
+++ b/mfr/core/exceptions.py
@@ -1,10 +1,16 @@
 import waterbutler.core.exceptions
+from mfr.server import settings
 
 
 class PluginError(waterbutler.core.exceptions.PluginError):
     """The MFR related errors raised from a plugin
     should inherit from PluginError
     """
+
+    def __init__(self, message, code=500, keen_data={}):
+        super().__init__(message, code)
+        if settings.KEEN_ERRORS_PROJECT_ID:
+            self.data = keen_data
 
     def as_html(self):
         return '''
@@ -21,6 +27,9 @@ class ExtensionError(PluginError):
     inherit from ExtensionError
     """
 
+    def __init__(self, message, code=500, keen_data={}):
+        super().__init__(message, code, keen_data=keen_data)
+
 
 class RendererError(ExtensionError):
     """The MFR related errors raised
@@ -28,12 +37,34 @@ class RendererError(ExtensionError):
     to rendering should inherit from RendererError
     """
 
+    def __init__(self, message, code=500, keen_data={}):
+        super().__init__(message, code, keen_data=keen_data)
+
+
+class MakeRendererError(ExtensionError):
+    """The MFR related errors raised
+    from a :def:`mfr.core.utils.make_renderer`
+    should inherit from MakeRendererError
+    """
+
+    def __init__(self, message, code=500, keen_data={}):
+        super().__init__(message, code, keen_data=keen_data)
+
 
 class ExporterError(ExtensionError):
     """The MFR related errors raised
     from a :class:`mfr.core.extension` and relating
     to exporting should inherit from ExporterError
     """
+
+class MakeExporterError(ExtensionError):
+    """The MFR related errors raised
+    from a :def:`mfr.core.utils.make_exporter`
+    should inherit from MakeExporterError
+    """
+
+    def __init__(self, message, code=500, keen_data={}):
+        super().__init__(message, code, keen_data=keen_data)
 
 
 class ProviderError(PluginError):
@@ -49,9 +80,17 @@ class DownloadError(ProviderError):
     to downloads should inherit from DownloadError
     """
 
+    def __init__(self, message, keen_data: dict ={}, code=500):
+        keen_data = {'DownloadError': keen_data}
+        super().__init__(message, code, keen_data=keen_data)
+
 
 class MetadataError(ProviderError):
     """The MFR related errors raised
     from a :class:`mfr.core.provider` and relating
     to metadata should inherit from MetadataError
     """
+
+    def __init__(self, message, keen_data: dict ={}, code=500):
+        keen_data = {'MetadataError': keen_data}
+        super().__init__(message, code, keen_data=keen_data)

--- a/mfr/core/utils.py
+++ b/mfr/core/utils.py
@@ -39,18 +39,16 @@ def make_exporter(name, source_file_path, output_file_path, format):
             invoke_args=(source_file_path, output_file_path, format),
         ).driver
     except RuntimeError:
-        keen_data = {'DriverArgs':
-                        {'namespace': 'mfr.renderers',
-                         'name': (name and name.lower()) or 'none',
-                         'invoke_on_load': True,
-                         'invoke_args':
-                             {'source_file_path': source_file_path,
-                              'output_file_path': output_file_path,
-                              'format': format}
-                         }
-                     }
+        driver_args = {'namespace': 'mfr.renderers',
+                       'name': (name and name.lower()) or 'none',
+                       'invoke_on_load': True,
+                       'invoke_args':
+                           {'source_file_path': source_file_path,
+                            'output_file_path': output_file_path,
+                            'format': format}
+                       }
         raise exceptions.MakeExporterError(settings.UNSUPPORTED_EXPORTER_MSG,
-                                       code=400, keen_data=keen_data)
+                                           driver_args, name, code=400)
 
 
 def make_renderer(name, metadata, file_path, url, assets_url, export_url):
@@ -73,17 +71,15 @@ def make_renderer(name, metadata, file_path, url, assets_url, export_url):
             invoke_args=(metadata, file_path, url, assets_url, export_url),
         ).driver
     except RuntimeError:
-        keen_data = {'DriverArgs':
-                        {'namespace': 'mfr.renderers',
-                         'name': (name and name.lower()) or 'none',
-                         'invoke_on_load': True,
-                         'invoke_args':
-                            {'metadata': metadata.serialize(),
-                             'file_path': file_path,
-                             'url': url,
-                             'assets_url': assets_url,
-                             'export_url': export_url}
-                         }
-                     }
+        driver_args = {'namespace': 'mfr.renderers',
+                       'name': (name and name.lower()) or 'none',
+                       'invoke_on_load': True,
+                       'invoke_args':
+                          {'metadata': metadata.serialize(),
+                           'file_path': file_path,
+                           'url': url,
+                           'assets_url': assets_url,
+                           'export_url': export_url}
+                       }
         raise exceptions.MakeRendererError(settings.UNSUPPORTED_RENDER_MSG,
-                                       code=400, keen_data=keen_data)
+                                           driver_args, metadata.ext, code=400)

--- a/mfr/core/utils.py
+++ b/mfr/core/utils.py
@@ -39,16 +39,14 @@ def make_exporter(name, source_file_path, output_file_path, format):
             invoke_args=(source_file_path, output_file_path, format),
         ).driver
     except RuntimeError:
-        keen_data = {'MakeExporterError':
-                        {'DriverArgs':
-                            {'namespace': 'mfr.renderers',
-                             'name': (name and name.lower()) or 'none',
-                             'invoke_on_load': True,
-                             'invoke_args':
-                                 {'source_file_path': source_file_path,
-                                  'output_file_path': output_file_path,
-                                  'format': format}
-                             }
+        keen_data = {'DriverArgs':
+                        {'namespace': 'mfr.renderers',
+                         'name': (name and name.lower()) or 'none',
+                         'invoke_on_load': True,
+                         'invoke_args':
+                             {'source_file_path': source_file_path,
+                              'output_file_path': output_file_path,
+                              'format': format}
                          }
                      }
         raise exceptions.MakeExporterError(settings.UNSUPPORTED_EXPORTER_MSG,
@@ -75,18 +73,16 @@ def make_renderer(name, metadata, file_path, url, assets_url, export_url):
             invoke_args=(metadata, file_path, url, assets_url, export_url),
         ).driver
     except RuntimeError:
-        keen_data = {'MakeRendererError':
-                        {'DriverArgs':
-                            {'namespace': 'mfr.renderers',
-                             'name': (name and name.lower()) or 'none',
-                             'invoke_on_load': True,
-                             'invoke_args':
-                                {'metadata': metadata.serialize(),
-                                 'file_path': file_path,
-                                 'url': url,
-                                 'assets_url': assets_url,
-                                 'export_url': export_url}
-                             }
+        keen_data = {'DriverArgs':
+                        {'namespace': 'mfr.renderers',
+                         'name': (name and name.lower()) or 'none',
+                         'invoke_on_load': True,
+                         'invoke_args':
+                            {'metadata': metadata.serialize(),
+                             'file_path': file_path,
+                             'url': url,
+                             'assets_url': assets_url,
+                             'export_url': export_url}
                          }
                      }
         raise exceptions.MakeRendererError(settings.UNSUPPORTED_RENDER_MSG,

--- a/mfr/core/utils.py
+++ b/mfr/core/utils.py
@@ -39,7 +39,20 @@ def make_exporter(name, source_file_path, output_file_path, format):
             invoke_args=(source_file_path, output_file_path, format),
         ).driver
     except RuntimeError:
-        raise exceptions.RendererError(settings.UNSUPPORTED_EXPORTER_MSG, code=400)
+        keen_data = {'MakeExporterError':
+                        {'DriverArgs':
+                            {'namespace': 'mfr.renderers',
+                             'name': (name and name.lower()) or 'none',
+                             'invoke_on_load': True,
+                             'invoke_args':
+                                 {'source_file_path': source_file_path,
+                                  'output_file_path': output_file_path,
+                                  'format': format}
+                             }
+                         }
+                     }
+        raise exceptions.MakeExporterError(settings.UNSUPPORTED_EXPORTER_MSG,
+                                       code=400, keen_data=keen_data)
 
 
 def make_renderer(name, metadata, file_path, url, assets_url, export_url):
@@ -62,4 +75,19 @@ def make_renderer(name, metadata, file_path, url, assets_url, export_url):
             invoke_args=(metadata, file_path, url, assets_url, export_url),
         ).driver
     except RuntimeError:
-        raise exceptions.RendererError(settings.UNSUPPORTED_RENDER_MSG, code=400)
+        keen_data = {'MakeRendererError':
+                        {'DriverArgs':
+                            {'namespace': 'mfr.renderers',
+                             'name': (name and name.lower()) or 'none',
+                             'invoke_on_load': True,
+                             'invoke_args':
+                                {'metadata': metadata.serialize(),
+                                 'file_path': file_path,
+                                 'url': url,
+                                 'assets_url': assets_url,
+                                 'export_url': export_url}
+                             }
+                         }
+                     }
+        raise exceptions.MakeRendererError(settings.UNSUPPORTED_RENDER_MSG,
+                                       code=400, keen_data=keen_data)

--- a/mfr/extensions/codepygments/exceptions.py
+++ b/mfr/extensions/codepygments/exceptions.py
@@ -7,5 +7,11 @@ class FileTooLargeError(RendererError):
     file to display should inherit from FileTooLargeError
     """
 
-    def __init__(self, message, keen_data: dict ={}, code=500):
-        super().__init__(message, code, keen_data=keen_data)
+    def __init__(self, message, file_size: int, max_size: int,
+                 renderer_class: str, extension: str, code: int=500):
+
+        self.keen_data = {'file_size': file_size,
+                          'max_size': max_size}
+
+        super().__init__(message, 'file_too_large', renderer_class,
+                         extension, code=code)

--- a/mfr/extensions/codepygments/exceptions.py
+++ b/mfr/extensions/codepygments/exceptions.py
@@ -15,3 +15,20 @@ class FileTooLargeError(RendererError):
 
         super().__init__(message, 'file_too_large', renderer_class,
                          extension, code=code)
+
+
+class FileDecodingError(RendererError):
+    """The codepygments related errors raised from a
+    :class:`mfr.extentions.codepygments` and relating to decoding of
+    file to display should inherit from FileDecodingError
+    """
+
+    def __init__(self, message, original_exception, original_message,
+                 renderer_class: str, extension: str, code: int=500):
+
+        self.keen_data = {'message': message,
+                          'original_exception': original_exception,
+                          'original_message': original_message}
+
+        super().__init__(message, 'file_decoding', renderer_class,
+                         extension, code=code)

--- a/mfr/extensions/codepygments/exceptions.py
+++ b/mfr/extensions/codepygments/exceptions.py
@@ -1,6 +1,11 @@
 from mfr.core.exceptions import RendererError
 
 
-class FileTooLargeException(RendererError):
-    def __init__(self, *args, **kwargs):
-        super().__init__(code=400, *args, **kwargs)
+class FileTooLargeError(RendererError):
+    """The codepygments related errors raised from a
+    :class:`mfr.extentions.codepygments` and relating to limit on size of
+    file to display should inherit from FileTooLargeError
+    """
+
+    def __init__(self, message, keen_data: dict ={}, code=500):
+        super().__init__(message, code, keen_data=keen_data)

--- a/mfr/extensions/codepygments/render.py
+++ b/mfr/extensions/codepygments/render.py
@@ -30,14 +30,7 @@ class CodePygmentsRenderer(extension.BaseRenderer):
     def render(self):
         file_size = os.path.getsize(self.file_path)
         if file_size > settings.MAX_SIZE:
-            keen_data = {'FileTooLargeError':
-                            {'file_size': file_size,
-                             'MAX_SIZE': settings.MAX_SIZE
-                             }
-                         }
-            raise cp_exceptions.FileTooLargeError(
-                'Text files larger than {} are not rendered. Please download the file to view.'.format(format_size(settings.MAX_SIZE, binary=True)),
-                keen_data=keen_data)
+            raise cp_exceptions.FileTooLargeError('Text files larger than {} are not rendered. Please download the file to view.'.format(format_size(settings.MAX_SIZE, binary=True)), file_size, settings.MAX_SIZE, self.__class__.__name__, self.metadata.ext)
 
         with open(self.file_path, 'rb') as fp:
             body = self._render_html(fp, self.metadata.ext)

--- a/mfr/extensions/codepygments/render.py
+++ b/mfr/extensions/codepygments/render.py
@@ -9,9 +9,9 @@ import pygments.formatters
 from pygments.util import ClassNotFound
 from mako.lookup import TemplateLookup
 
-from mfr.core import extension, exceptions
+from mfr.core import extension
 from mfr.extensions.codepygments import settings
-from mfr.extensions.codepygments import exceptions as cp_exceptions
+from mfr.extensions.codepygments import exceptions
 
 
 class CodePygmentsRenderer(extension.BaseRenderer):
@@ -30,7 +30,7 @@ class CodePygmentsRenderer(extension.BaseRenderer):
     def render(self):
         file_size = os.path.getsize(self.file_path)
         if file_size > settings.MAX_SIZE:
-            raise cp_exceptions.FileTooLargeError('Text files larger than {} are not rendered. Please download the file to view.'.format(format_size(settings.MAX_SIZE, binary=True)), file_size, settings.MAX_SIZE, self.__class__.__name__, self.metadata.ext)
+            raise exceptions.FileTooLargeError('Text files larger than {} are not rendered. Please download the file to view.'.format(format_size(settings.MAX_SIZE, binary=True)), file_size, settings.MAX_SIZE, self.__class__.__name__, self.metadata.ext)
 
         with open(self.file_path, 'rb') as fp:
             body = self._render_html(fp, self.metadata.ext)
@@ -53,28 +53,33 @@ class CodePygmentsRenderer(extension.BaseRenderer):
         formatter = pygments.formatters.HtmlFormatter()
         data = fp.read()
 
-        content, exception, encoding = None, None, 'utf-8'
+        content, exception_message, encoding = None, None, 'utf-8'
         try:
             content = data.decode(encoding)
-        except UnicodeDecodeError as e:
-            exception = e
-
-        if exception is not None:
+        except UnicodeDecodeError as err:
             detected_encoding = chardet.detect(data)
             try:
                 encoding = detected_encoding['encoding']
                 content = data.decode(encoding)
-            except KeyError:
-                exception = exceptions.RendererError(
-                    'Unable to detect encoding of source file', code=400)
-            except UnicodeDecodeError as e:
-                exception = e
+            except KeyError as err:
+                original_exception = err.__class__.__name__
+                original_message = str(err)
+                exception_message = 'Unable to detect encoding of source file.'
+            except UnicodeDecodeError as err:
+                original_exception = err.__class__.__name__
+                original_message = str(err)
+                exception_message = 'Unable to decode file as {}.'.format(encoding)
 
         if content is None:
-            assert exception is not None, 'Got no content or exception'
-            if isinstance(exception, UnicodeDecodeError):
-                exception = exceptions.RendererError('Unable to decode file as {}'.format(encoding), code=400)
-            raise exception
+            if exception_message is None:
+                original_exception = ''
+                original_message = ''
+                exception_message = 'Got no content or exception.'
+            raise exceptions.FileDecodingError(exception_message,
+                                               original_exception,
+                                               original_message,
+                                               self.__class__.__name__,
+                                               ext, code=400)
 
         self.metrics.merge({'encoding': encoding, 'default_lexer': False})
 

--- a/mfr/extensions/codepygments/render.py
+++ b/mfr/extensions/codepygments/render.py
@@ -30,10 +30,14 @@ class CodePygmentsRenderer(extension.BaseRenderer):
     def render(self):
         file_size = os.path.getsize(self.file_path)
         if file_size > settings.MAX_SIZE:
-            raise cp_exceptions.FileTooLargeException(
-                'Text files larger than {} are not rendered. Please download the file to '
-                'view.'.format(format_size(settings.MAX_SIZE, binary=True))
-            )
+            keen_data = {'FileTooLargeError':
+                            {'file_size': file_size,
+                             'MAX_SIZE': settings.MAX_SIZE
+                             }
+                         }
+            raise cp_exceptions.FileTooLargeError(
+                'Text files larger than {} are not rendered. Please download the file to view.'.format(format_size(settings.MAX_SIZE, binary=True)),
+                keen_data=keen_data)
 
         with open(self.file_path, 'rb') as fp:
             body = self._render_html(fp, self.metadata.ext)

--- a/mfr/extensions/image/exceptions.py
+++ b/mfr/extensions/image/exceptions.py
@@ -5,3 +5,15 @@ class PillowImageError(ExporterError):
     """The Image related errors raised from a :class:`mfr.extentions.image`
     and relating to the Pillow Library should inherit from PillowImageError
     """
+
+    def __init__(self, message, file_name_ext, imghdr_type, original_message,
+                 original_exception, exporter_class: str, extension: str,
+                 code: int=500):
+
+        self.keen_data = {'file_name_ext': file_name_ext,
+                          'imghdr_type': imghdr_type,
+                          'original_message': original_message,
+                          'original_exception': original_exception}
+
+        super().__init__(message, 'pillow_image', exporter_class, extension,
+                         code=code)

--- a/mfr/extensions/image/exceptions.py
+++ b/mfr/extensions/image/exceptions.py
@@ -5,7 +5,3 @@ class PillowImageError(ExporterError):
     """The Image related errors raised from a :class:`mfr.extentions.image`
     and relating to the Pillow Library should inherit from PillowImageError
     """
-
-    def __init__(self, message, keen_data: dict ={}, code=500):
-        keen_data = {'PillowImageError': keen_data}
-        super().__init__(message, code, keen_data=keen_data)

--- a/mfr/extensions/image/exceptions.py
+++ b/mfr/extensions/image/exceptions.py
@@ -1,0 +1,11 @@
+from mfr.core.exceptions import ExporterError
+
+
+class PillowImageError(ExporterError):
+    """The Image related errors raised from a :class:`mfr.extentions.image`
+    and relating to the Pillow Library should inherit from PillowImageError
+    """
+
+    def __init__(self, message, keen_data: dict ={}, code=500):
+        keen_data = {'PillowImageError': keen_data}
+        super().__init__(message, code, keen_data=keen_data)

--- a/mfr/extensions/image/export.py
+++ b/mfr/extensions/image/export.py
@@ -48,4 +48,7 @@ class ImageExporter(extension.BaseExporter):
             exported_image.save(self.output_file_path, type)
             exported_image.close()
         except UnicodeDecodeError:
-            raise exceptions.ExporterError('Unable to export the file in the requested format, please try again later.', code=400)
+            keen_data = {'type': 'image_export',
+                         'image_type': type,
+                         'path': str(self.source_file_path)}
+            raise exceptions.ExporterError('Unable to export the file in the requested format, please try again later.', code=400, keen_data=keen_data)

--- a/mfr/extensions/ipynb/exceptions.py
+++ b/mfr/extensions/ipynb/exceptions.py
@@ -1,5 +1,15 @@
 from mfr.core.exceptions import RendererError
 
 
-class InvalidFormat(RendererError):
-    pass
+class InvalidFormatError(RendererError):
+
+    def __init__(self, message, download_url: str, original_exception: str,
+                 original_message: str, renderer_class: str, extension: str,
+                 code: int=500):
+
+        self.keen_data = {'download_url': download_url,
+                          'original_exception': original_exception,
+                          'original_message': original_message}
+
+        super().__init__(message, 'invalid_format', renderer_class,
+                         extension, code=code)

--- a/mfr/extensions/ipynb/render.py
+++ b/mfr/extensions/ipynb/render.py
@@ -26,8 +26,8 @@ class IpynbRenderer(extension.BaseRenderer):
         try:
             with open(self.file_path, 'r') as file_pointer:
                 notebook = nbformat.reads(file_pointer.read(), as_version=4)
-        except ValueError:
-            raise exceptions.InvalidFormat('Could not read ipython notebook file.')
+        except ValueError as err:
+            raise exceptions.InvalidFormatError('Could not read ipython notebook file. {}'.format(str(err)), str(self.metadata.download_url), err.__class__.__name__, str(err), self.__class__.__name__, self.metadata.ext)
 
         exporter = HTMLExporter(config=Config({
             'HTMLExporter': {

--- a/mfr/extensions/jasp/exceptions.py
+++ b/mfr/extensions/jasp/exceptions.py
@@ -6,9 +6,15 @@ class JaspVersionError(RendererError):
     relating to minimum data archive version should inherit from RendererError
     """
 
-    def __init__(self, message, keen_data: dict ={}, code=500):
-        keen_data = {'JaspVersionError': keen_data}
-        super().__init__(message, code, keen_data=keen_data)
+    def __init__(self, message, created_by: str, data_archive_version: str,
+                 minimum_version: str, renderer_class: str, extension: str,
+                 code=500):
+        self.keen_data = {'created_by': created_by,
+                          'data_archive_version': data_archive_version,
+                          'minimum_version': minimum_version
+                          }
+        super().__init__(message, 'jasp_version', renderer_class,
+                         extension, code=code)
 
 
 class JaspFileCorruptError(RendererError):
@@ -16,6 +22,9 @@ class JaspFileCorruptError(RendererError):
     relating to failure while consuming JASP file should inherit from RendererError
     """
 
-    def __init__(self, message, keen_data: dict ={}, code=500):
-        keen_data = {'JaspFileCorruptError': keen_data}
-        super().__init__(message, code, keen_data=keen_data)
+    def __init__(self, message, name: str, reason: str, renderer_class: str,
+                 extension: str, code=500):
+        self.keen_data = {'name': name,
+                          'reason': reason}
+        super().__init__(message, 'jasp_file_corrupt', renderer_class,
+                         extension, code=code)

--- a/mfr/extensions/jasp/exceptions.py
+++ b/mfr/extensions/jasp/exceptions.py
@@ -1,0 +1,21 @@
+from mfr.core.exceptions import RendererError
+
+
+class JaspVersionError(RendererError):
+    """The jasp related errors raised from a :class:`mfr.extentions.jasp` and
+    relating to minimum data archive version should inherit from RendererError
+    """
+
+    def __init__(self, message, keen_data: dict ={}, code=500):
+        keen_data = {'JaspVersionError': keen_data}
+        super().__init__(message, code, keen_data=keen_data)
+
+
+class JaspFileCorruptError(RendererError):
+    """The jasp related errors raised from a :class:`mfr.extentions.jasp` and
+    relating to failure while consuming JASP file should inherit from RendererError
+    """
+
+    def __init__(self, message, keen_data: dict ={}, code=500):
+        keen_data = {'JaspFileCorruptError': keen_data}
+        super().__init__(message, code, keen_data=keen_data)

--- a/mfr/extensions/tabular/exceptions.py
+++ b/mfr/extensions/tabular/exceptions.py
@@ -1,17 +1,41 @@
 from mfr.core.exceptions import RendererError
 
 
-class MissingRequirementsException(RendererError):
-    pass
+class MissingRequirementsError(RendererError):
+    def __init__(self, message, function_preference, renderer_class: str,
+                 extension: str, code: int=500):
+
+        self.keen_data = {'function_preference': function_preference}
+
+        super().__init__(message, 'missing_requirements', renderer_class,
+                         extension, code=code)
 
 
-class EmptyTableException(RendererError):
-    pass
+class EmptyTableError(RendererError):
+    def __init__(self, message, renderer_class: str,
+                 extension: str, code: int=500):
+
+        self.keen_data = {}
+
+        super().__init__(message, 'empty_table', renderer_class,
+                         extension, code=code)
 
 
-class TableTooBigException(RendererError):
-    pass
+class TableTooBigError(RendererError):
+    def __init__(self, message, renderer_class: str,
+                 extension: str, code: int=500):
+
+        self.keen_data = {}
+
+        super().__init__(message, 'table_too_big', renderer_class,
+                         extension, code=code)
 
 
-class UnexpectedFormattingException(RendererError):
-    pass
+class UnexpectedFormattingError(RendererError):
+    def __init__(self, message, formatting_function: str, renderer_class: str,
+                 extension: str, code: int=500):
+
+        self.keen_data = {'formatting_function': formatting_function}
+
+        super().__init__(message, 'unexpected_formatting', renderer_class,
+                         extension, code=code)

--- a/mfr/extensions/tabular/libs/ezodf_tools.py
+++ b/mfr/extensions/tabular/libs/ezodf_tools.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 from ..utilities import data_population, header_population
 
 
-def ods_ezodf(fp):
+def ods_ezodf(fp, renderer_class, extension):
     """Read and convert a ods file to JSON format using the ezodf library
     :param fp: File pointer object
     :return: tuple of table headers and data

--- a/mfr/extensions/tabular/libs/panda_tools.py
+++ b/mfr/extensions/tabular/libs/panda_tools.py
@@ -28,7 +28,7 @@ def tsv_pandas(fp):
     return data_from_dataframe(dataframe)
 
 
-def dta_pandas(fp):
+def dta_pandas(fp, renderer_class, extension):
     """Read and convert a dta file to JSON format using the pandas library
     :param fp: File pointer object
     :return: tuple of table headers and data

--- a/mfr/extensions/tabular/libs/stdlib_tools.py
+++ b/mfr/extensions/tabular/libs/stdlib_tools.py
@@ -45,7 +45,7 @@ def csv_stdlib(fp, renderer_class, extension):
     return {'Sheet 1': (columns, rows)}
 
 
-def sav_stdlib(fp):
+def sav_stdlib(fp, renderer_class, extension):
     """Read and convert a .sav file to .csv with pspp, then convert that to JSON format using
     the python standard library
 
@@ -55,7 +55,7 @@ def sav_stdlib(fp):
     csv_file = utilities.sav_to_csv(fp)
     with open(csv_file.name, 'r') as file:
         csv_file.close()
-        return csv_stdlib(file)
+        return csv_stdlib(file, renderer_class, extension)
 
 
 def _set_dialect_quote_attrs(dialect, data):

--- a/mfr/extensions/tabular/libs/stdlib_tools.py
+++ b/mfr/extensions/tabular/libs/stdlib_tools.py
@@ -1,11 +1,11 @@
 import re
 import csv
 
-from ..exceptions import EmptyTableException
+from mfr.extensions.tabular.exceptions import EmptyTableError
 from mfr.extensions.tabular import utilities
 
 
-def csv_stdlib(fp):
+def csv_stdlib(fp, renderer_class, extension):
     """Read and convert a csv file to JSON format using the python standard library
     :param fp: File pointer object
     :return: tuple of table headers and data
@@ -39,7 +39,8 @@ def csv_stdlib(fp):
     rows = [row for row in reader]
 
     if not columns and not rows:
-        raise EmptyTableException("Table empty or corrupt.")
+        raise EmptyTableError('Table empty or corrupt.', renderer_class,
+                              extension)
 
     return {'Sheet 1': (columns, rows)}
 

--- a/mfr/extensions/tabular/libs/xlrd_tools.py
+++ b/mfr/extensions/tabular/libs/xlrd_tools.py
@@ -1,12 +1,12 @@
 import xlrd
 from collections import OrderedDict
-from ..exceptions import TableTooBigException
+from ..exceptions import TableTooBigError
 
 from ..utilities import header_population
 from mfr.extensions.tabular.compat import range, basestring
 
 
-def xlsx_xlrd(fp):
+def xlsx_xlrd(fp, renderer_class, extension):
     """Read and convert a xlsx file to JSON format using the xlrd library
     :param fp: File pointer object
     :return: tuple of table headers and data
@@ -19,7 +19,8 @@ def xlsx_xlrd(fp):
 
     for sheet in wb.sheets():
         if sheet.ncols > max_size or sheet.nrows > max_size:
-            raise TableTooBigException("Table is too large to render.")
+            raise TableTooBigError('Table is too large to render.',
+                                       renderer_class, extension)
 
         if sheet.ncols < 1 or sheet.nrows < 1:
             sheets[sheet.name] = ([], [])

--- a/mfr/extensions/tabular/render.py
+++ b/mfr/extensions/tabular/render.py
@@ -68,13 +68,19 @@ class TabularRenderer(extension.BaseRenderer):
         for function in function_preference:
             try:
                 imported = function()
+            # TODO missing function raises AttributeError not ImportError
             except ImportError:
                 pass
+            # TODO if this else is reached will either return or raise.
+            # will not try next function.
             else:
                 self._renderer_tabular_metrics['importer'] = function.__name__
                 try:
-                    return imported(fp)
+                    return imported(fp, self.__class__.__name__,
+                                    self.metadata.ext)
                 except KeyError:
-                    raise exceptions.UnexpectedFormattingException()
+                    raise exceptions.UnexpectedFormattingError('Unexpected formatting error.', str(function), self.__class__.__name__, self.metadata.ext)
 
-        raise exceptions.MissingRequirementsException('Renderer requirements are not met')
+        # TODO this raise will only occur if function_preference is an empty set
+        # or all functions in the set raise an import error
+        raise exceptions.MissingRequirementsError('Renderer requirements are not met', function_preference, self.__class__.__name__, self.metadata.ext)

--- a/mfr/extensions/tabular/settings.py
+++ b/mfr/extensions/tabular/settings.py
@@ -8,6 +8,8 @@ MAX_SIZE = int(config.get('MAX_SIZE', 10000))
 TABLE_WIDTH = int(config.get('TABLE_WIDTH', 700))
 TABLE_HEIGHT = int(config.get('TABLE_HEIGHT', 600))
 
+# All libs called from here must take args (fp, renderer_class, extension)
+# renderer_class, and extension to be passed to exception if raised in lib
 LIBS = config.get('LIBS', {
     '.csv': [libs.csv_stdlib],
     '.tsv': [libs.csv_stdlib],

--- a/mfr/extensions/tabular/utilities.py
+++ b/mfr/extensions/tabular/utilities.py
@@ -48,17 +48,14 @@ def sav_to_csv(fp):
     """
     csv_file = NamedTemporaryFile(mode='w+b', suffix='.csv')
     try:
+        raise subprocess.CalledProcessError('oops', 'cmd')
         subprocess.check_call([
             settings.PSPP_CONVERT_BIN,
             fp.name,
             csv_file.name,
         ])
     except subprocess.CalledProcessError as err:
-        keen_data = {'type': 'unoconv',
-                     'unoconv_cmd': str(err.cmd),
-                     'unoconv_returncode': err.returncode,
-                     'path': fp.name}
         raise exceptions.SubprocessError(
             'Unable to convert the SPSS file to CSV, please try again later.',
-            code=400, keen_data=keen_data)
+            'unoconv', str(err.cmd), err.returncode, fp.name, '.sav', code=400)
     return csv_file

--- a/mfr/extensions/tabular/utilities.py
+++ b/mfr/extensions/tabular/utilities.py
@@ -53,7 +53,12 @@ def sav_to_csv(fp):
             fp.name,
             csv_file.name,
         ])
-    except subprocess.CalledProcessError:
-        raise exceptions.ExporterError(
-            'Unable to convert the SPSS file to CSV, please try again later.', code=400)
+    except subprocess.CalledProcessError as err:
+        keen_data = {'type': 'unoconv',
+                     'unoconv_cmd': str(err.cmd),
+                     'unoconv_returncode': err.returncode,
+                     'path': fp.name}
+        raise exceptions.SubprocessError(
+            'Unable to convert the SPSS file to CSV, please try again later.',
+            code=400, keen_data=keen_data)
     return csv_file

--- a/mfr/extensions/unoconv/export.py
+++ b/mfr/extensions/unoconv/export.py
@@ -19,5 +19,9 @@ class UnoconvExporter(extension.BaseExporter):
                 '-vvv',
                 self.source_file_path
             ])
-        except subprocess.CalledProcessError:
-            raise exceptions.ExporterError('Unable to export the file in the requested format, please try again later.', code=400)
+        except subprocess.CalledProcessError as err:
+            keen_data = {'type': 'unoconv',
+                         'unoconv_cmd': str(err.cmd),
+                         'unoconv_returncode': err.returncode,
+                         'path': str(self.source_file_path)}
+            raise exceptions.SubprocessError('Unable to export the file in the requested format, please try again later.', code=400, keen_data=keen_data)

--- a/mfr/providers/http/provider.py
+++ b/mfr/providers/http/provider.py
@@ -1,4 +1,5 @@
 import os
+import ast
 import hashlib
 import logging
 import mimetypes
@@ -33,8 +34,10 @@ class HttpProvider(provider.BaseProvider):
         if response.status >= 400:
             err_resp = await response.read()
             logger.error('Unable to download file: ({}) {}'.format(response.status, err_resp.decode('utf-8')))
-            raise exceptions.ProviderError(
+            resp_text = await response.text()
+            keen_data = {'download_url': self.url,
+                         'response': ast.literal_eval(resp_text)}
+            raise exceptions.DownloadError(
                 'Unable to download the requested file, please try again later.',
-                code=response.status
-            )
+                code=response.status, keen_data=keen_data)
         return streams.ResponseStreamReader(response)

--- a/mfr/providers/osf/provider.py
+++ b/mfr/providers/osf/provider.py
@@ -1,5 +1,4 @@
 import os
-import ast
 import json
 import hashlib
 import logging
@@ -74,10 +73,7 @@ class OsfProvider(provider.BaseProvider):
                 await metadata_request.release()
             except KeyError:
                 resp_text = await metadata_request.text()
-                keen_data = {'metadata_url': download_url,
-                             'response': ast.literal_eval(resp_text)
-                             }
-                raise exceptions.MetadataError('Failed to fetch metadata. Received response code {}'.format(str(metadata_request.status)), code=400, keen_data=keen_data)
+                raise exceptions.MetadataError('Failed to fetch metadata. Received response code {}'.format(str(metadata_request.status)), download_url, resp_text, self.NAME, code=400)
             except ContentEncodingError:
                 pass  # hack: aiohttp tries to unzip empty body when Content-Encoding is set
 
@@ -109,14 +105,11 @@ class OsfProvider(provider.BaseProvider):
         response = await self._make_request('GET', download_url, allow_redirects=False, headers=headers)
 
         if response.status >= 400:
-            err_resp = await response.text()
-            logger.error('Unable to download file: ({}) {}'.format(response.status, err_resp))
-            keen_data = {'download_url': download_url,
-                         'response': ast.literal_eval(err_resp)
-                         }
+            resp_text = await response.text()
+            logger.error('Unable to download file: ({}) {}'.format(response.status, resp_text))
             raise exceptions.DownloadError(
                 'Unable to download the requested file, please try again later.',
-                code=response.status, keen_data=keen_data)
+                download_url, resp_text, self.NAME)
 
         self.metrics.add('download.saw_redirect', False)
         if response.status in (302, 301):
@@ -154,11 +147,7 @@ class OsfProvider(provider.BaseProvider):
                 await request.release()
 
                 if request.status != 302:
-                    keen_data = {'metadata_url': self.url,
-                                 'response': ast.literal_eval(resp_text)
-                                 }
-                    raise exceptions.MetadataError(request.reason, request.status,
-                                                   keen_data=keen_data)
+                    raise exceptions.MetadataError(request.reason, self.url, resp_text, self.NAME, code=request.status)
                 self.download_url = request.headers['location']
 
             self.metrics.add('download_url.derived_url', str(self.download_url))

--- a/mfr/server/app.py
+++ b/mfr/server/app.py
@@ -14,8 +14,18 @@ from mfr.server.handlers.export import ExportHandler
 from mfr.server.handlers.render import RenderHandler
 from mfr.server.handlers.status import StatusHandler
 from mfr.server.handlers.core import ExtensionsStaticFileHandler
+from mfr.core import remote_logging
 
 logger = logging.getLogger(__name__)
+
+if server_settings.KEEN_ERRORS_PROJECT_ID is None:
+    logger.info('No KEEN_ERRORS_PROJECT_ID configured. Errors will not be logged to keen.io')
+else:
+    keen_err_logger = logging.getLogger('keen_err_logger')
+    keen_err_handler = remote_logging.KeenHandler('mfr_errors',
+                                    server_settings.KEEN_ERRORS_PROJECT_ID,
+                                    server_settings.KEEN_ERRORS_WRITE_KEY)
+    keen_err_logger.addHandler(keen_err_handler)
 
 
 def make_app(debug):

--- a/mfr/server/app.py
+++ b/mfr/server/app.py
@@ -18,13 +18,13 @@ from mfr.core import remote_logging
 
 logger = logging.getLogger(__name__)
 
-if server_settings.KEEN_ERRORS_PROJECT_ID is None:
-    logger.info('No KEEN_ERRORS_PROJECT_ID configured. Errors will not be logged to keen.io')
+if server_settings.KEEN_PRIVATE_PROJECT_ID is None:
+    logger.info('No KEEN_PRIVATE_PROJECT_ID configured. Exceptions will not be logged to keen.io')
 else:
     keen_err_logger = logging.getLogger('keen_err_logger')
     keen_err_handler = remote_logging.KeenHandler('mfr_errors',
-                                    server_settings.KEEN_ERRORS_PROJECT_ID,
-                                    server_settings.KEEN_ERRORS_WRITE_KEY)
+                                    server_settings.KEEN_PRIVATE_PROJECT_ID,
+                                    server_settings.KEEN_PRIVATE_WRITE_KEY)
     keen_err_logger.addHandler(keen_err_handler)
 
 

--- a/mfr/server/handlers/core.py
+++ b/mfr/server/handlers/core.py
@@ -106,7 +106,10 @@ class BaseHandler(CorsMixin, tornado.web.RequestHandler, SentryMixin):
         try:
             self.url = self.request.query_arguments['url'][0].decode('utf-8')
         except KeyError:
-            raise exceptions.ProviderError('"url" is a required argument.', code=400)
+            keen_data = {'type': 'prepare_no_url',
+                         'provider': settings.PROVIDER_NAME}
+            raise exceptions.ProviderError('"url" is a required argument.',
+                                           code=400, keen_data=keen_data)
 
         self.provider = utils.make_provider(
             settings.PROVIDER_NAME,

--- a/mfr/server/handlers/core.py
+++ b/mfr/server/handlers/core.py
@@ -172,7 +172,9 @@ class BaseHandler(CorsMixin, tornado.web.RequestHandler, SentryMixin):
                                       'message': exc.message,
                                       'nomen': exc.nomen,
                                       'error_{}'.format(exc.nomen): exc.data})
-        self._final_handler_merge()
+        # MetadataError will have no cache/file info
+        if getattr(self, 'cache_file_id', None):
+            self._final_handler_merge()
         keen_event = self._all_metrics()
         keen_event['error'] = self.error_metrics.serialize()
         logger = logging.getLogger('keen_err_logger')
@@ -220,8 +222,8 @@ class BaseHandler(CorsMixin, tornado.web.RequestHandler, SentryMixin):
         return {
             'handler': self.handler_metrics.serialize(),
             'provider': self.provider.provider_metrics.serialize(),
-            'file': self.metadata.serialize(),
             'extension': self.extension_metrics.serialize(),
+            'file': self.metadata.serialize() if hasattr(self, 'metadata') else None,
             'renderer': self.renderer_metrics.serialize() if hasattr(self, 'renderer_metrics') else None,
             'exporter': self.exporter_metrics.serialize() if hasattr(self, 'exporter_metrics') else None,
         }

--- a/mfr/server/settings.py
+++ b/mfr/server/settings.py
@@ -51,7 +51,3 @@ KEEN_PRIVATE_WRITE_KEY = keen_private_config.get_nullable('WRITE_KEY', None)
 keen_public_config = keen_config.child('PUBLIC')
 KEEN_PUBLIC_PROJECT_ID = keen_public_config.get_nullable('PROJECT_ID', None)
 KEEN_PUBLIC_WRITE_KEY = keen_public_config.get_nullable('WRITE_KEY', None)
-
-keen_errors_config = keen_config.child('ERRORS')
-KEEN_ERRORS_PROJECT_ID = keen_errors_config.get_nullable('PROJECT_ID', None)
-KEEN_ERRORS_WRITE_KEY = keen_errors_config.get_nullable('WRITE_KEY', None)

--- a/mfr/server/settings.py
+++ b/mfr/server/settings.py
@@ -51,3 +51,7 @@ KEEN_PRIVATE_WRITE_KEY = keen_private_config.get_nullable('WRITE_KEY', None)
 keen_public_config = keen_config.child('PUBLIC')
 KEEN_PUBLIC_PROJECT_ID = keen_public_config.get_nullable('PROJECT_ID', None)
 KEEN_PUBLIC_WRITE_KEY = keen_public_config.get_nullable('WRITE_KEY', None)
+
+keen_errors_config = keen_config.child('ERRORS')
+KEEN_ERRORS_PROJECT_ID = keen_errors_config.get_nullable('PROJECT_ID', None)
+KEEN_ERRORS_WRITE_KEY = keen_errors_config.get_nullable('WRITE_KEY', None)

--- a/tests/extensions/codepygments/test_renderer.py
+++ b/tests/extensions/codepygments/test_renderer.py
@@ -6,7 +6,7 @@ from mfr.core.exceptions import RendererError
 from mfr.core.provider import ProviderMetadata
 
 from mfr.extensions.codepygments import settings, CodePygmentsRenderer
-from mfr.extensions.codepygments.exceptions import FileTooLargeException
+from mfr.extensions.codepygments.exceptions import FileTooLargeError
 
 
 @pytest.fixture
@@ -92,7 +92,7 @@ class TestCodePygmentsRenderer:
             os.remove(max_size_file_path)
 
     def test_render_codepygments_over_size(self, metadata, over_size_file_path, url, assets_url, export_url):
-        with pytest.raises(FileTooLargeException):
+        with pytest.raises(FileTooLargeError):
             try:
                 renderer = CodePygmentsRenderer(metadata, over_size_file_path,
                                                 url, assets_url, export_url)

--- a/tests/extensions/ipynb/test_renderer.py
+++ b/tests/extensions/ipynb/test_renderer.py
@@ -4,7 +4,7 @@ import pytest
 from mfr.core.provider import ProviderMetadata
 
 from mfr.extensions.ipynb import IpynbRenderer
-from mfr.extensions.ipynb.exceptions import InvalidFormat
+from mfr.extensions.ipynb.exceptions import InvalidFormatError
 
 
 @pytest.fixture
@@ -60,7 +60,7 @@ class TestIpynbRenderer:
 
     def test_render_ipynb_invalid_json(self, metadata, invalid_json_file_path, url, assets_url, export_url):
         renderer = IpynbRenderer(metadata, invalid_json_file_path, url, assets_url, export_url)
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(InvalidFormatError):
             renderer.render()
 
     def test_render_docx_file_required(self, renderer):

--- a/tests/extensions/tabular/test_renderer.py
+++ b/tests/extensions/tabular/test_renderer.py
@@ -85,7 +85,7 @@ class TestTabularCsvRenderer:
     def test_render_tabular_csv_invalid(self, invalid_csv_file_path, assets_url, export_url):
         metadata = ProviderMetadata('test', '.csv', 'text/plain', '1234', 'http://wb.osf.io/file/test.csv?token=1234')
         renderer = TabularRenderer(metadata, invalid_csv_file_path, url, assets_url, export_url)
-        with pytest.raises(exceptions.EmptyTableException):
+        with pytest.raises(exceptions.EmptyTableError):
             renderer.render()
 
 
@@ -100,7 +100,7 @@ class TestTabularTsvRenderer:
     def test_render_tabular_tsv_invalid(self, invalid_tsv_file_path, assets_url, export_url):
         metadata = ProviderMetadata('test', '.tsv', 'text/plain', '1234', 'http://wb.osf.io/file/test.tsv?token=1234')
         renderer = TabularRenderer(metadata, invalid_tsv_file_path, url, assets_url, export_url)
-        with pytest.raises(exceptions.EmptyTableException):
+        with pytest.raises(exceptions.EmptyTableError):
             renderer.render()
 
 

--- a/tests/extensions/tabular/test_xlsx_tools.py
+++ b/tests/extensions/tabular/test_xlsx_tools.py
@@ -9,7 +9,7 @@ class TestTabularPandaTools:
 
     def test_xlsx_xlrd(self):
         with open(os.path.join(BASE, 'files', 'test.xlsx')) as fp:
-            sheets = xlrd_tools.xlsx_xlrd(fp)
+            sheets = xlrd_tools.xlsx_xlrd(fp, 'TabularRenderer', '.xlsx')
 
         sheet = sheets.popitem()[1]
         assert sheet[0][0] == {'field': 'one', 'id': 'one', 'name': 'one', 'sortable': True}


### PR DESCRIPTION
## Purpose:
[OSF-7177](https://openscience.atlassian.net/browse/OSF-7177)
Add facility for logging errors to keen.io
Configure most salient errors to log to keen.io
Use python std library:logging logger/handler idiom

## Changes:
Update exceptions to pass keen_data on raise
    mfr/core/exceptions.py
    mfr/extensions/codepygments/exceptions.py
    mfr/extensions/image/exceptions.py
    mfr/extensions/jasp/exceptions.py

Add logging keen_logger and handler keen_handler for use in logger/handler idiom
    mfr/server/app.py
    mfr/core/remote_logging.py 

Configure keen_data for most salient errors
    mfr/core/utils.py
    mfr/extensions/codepygments/render.py
    mfr/extensions/image/export.py
    mfr/extensions/jasp/render.py
    mfr/providers/osf/provider.py

Add call to keen_logger when error received by tornado.
Add generic keen_data for all keen_logger calls
    mfr/server/handlers/core.py

Add config to settings for separate keen collection for errors
    mfr/server/settings.py

## Side effects
None

## Configuration
Current requires an ID and Key be configured so as to allow for using a separate keen collection. 
~/.cos/mfr-test.json
```
{                                                                                   
  "SERVER_CONFIG": {                                                                
    "ANALYTICS": {                                                                  
      "KEEN": {                                                                     
    ┆   "ERRORS": {                                                                 
    ┆   ┆ "PROJECT_ID": "",                                 
    ┆   ┆ "WRITE_KEY": ""                                   
        },
.....
```
[#OSF-7177]