### PR TITLE
[SVCS-123] Updates to invoke 0.13.0 and allows read-the-docs to read Python 3

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -175,11 +175,6 @@ html_sidebars = {
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'mfrdoc'
 
-latex_documents = [
-    ('documentation', False),
-]
-
-
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
 # On RTD we can't import sphinx_rtd_theme, but it will be applied by

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,16 @@
+name: py35
+dependencies:
+- openssl=1.0.2g=0
+- pip=8.1.1=py35_0
+- python=3.5.1=0
+- readline=6.2=2
+- setuptools=20.3=py35_0
+- sqlite=3.9.2=0
+- tk=8.5.18=0
+- wheel=0.29.0=py35_0
+- xz=5.0.5=1
+- zlib=1.2.8=0
+- pip:
+  - momoko>=2.2.3
+  - psycopg2>=2.6.1
+  - tornado==4.3

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,2 @@
+conda:
+    file: environment.yml

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ aiohttp==0.18.4
 chardet==2.3.0
 furl==0.4.2
 humanfriendly==2.1
-invoke==0.11.1
+invoke==0.13.0
 mako==1.0.1
 raven==5.27.0
 setuptools==30.4.0


### PR DESCRIPTION
# Purpose

Upgrade invoke to 0.13.0 and write a work around so mfr can use python 3 with read-the-docs.

# Changes

minor changes to task.py and addition config files for read the docs.

# Side Effects

None that I know of.

# Ticket

https://openscience.atlassian.net/browse/SVCS-123