### PR TITLE
[SVCS-123] Allows read-the-docs to read Python 3

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -175,11 +175,6 @@ html_sidebars = {
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'mfrdoc'
 
-latex_documents = [
-    ('documentation', False),
-]
-
-
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
 # On RTD we can't import sphinx_rtd_theme, but it will be applied by

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,16 @@
+name: py35
+dependencies:
+- openssl=1.0.2g=0
+- pip=8.1.1=py35_0
+- python=3.5.1=0
+- readline=6.2=2
+- setuptools=20.3=py35_0
+- sqlite=3.9.2=0
+- tk=8.5.18=0
+- wheel=0.29.0=py35_0
+- xz=5.0.5=1
+- zlib=1.2.8=0
+- pip:
+  - momoko>=2.2.3
+  - psycopg2>=2.6.1
+  - tornado==4.3

--- a/environment.yml
+++ b/environment.yml
@@ -1,16 +1,33 @@
 name: py35
 dependencies:
-- openssl=1.0.2g=0
 - pip=8.1.1=py35_0
 - python=3.5.1=0
-- readline=6.2=2
 - setuptools=20.3=py35_0
-- sqlite=3.9.2=0
-- tk=8.5.18=0
 - wheel=0.29.0=py35_0
-- xz=5.0.5=1
-- zlib=1.2.8=0
 - pip:
-  - momoko>=2.2.3
-  - psycopg2>=2.6.1
-  - tornado==4.3
+    - aiohttp==0.18.4
+    - chardet==2.3.0
+    - furl==0.4.2
+    - humanfriendly==2.1
+    - invoke==0.11.1
+    - mako==1.0.1
+    - raven==5.27.0
+    - setuptools==30.4.0
+    - stevedore==1.2.0
+    - tornado==4.3
+    - git+https://github.com/CenterForOpenScience/waterbutler.git@0.19.0#egg=waterbutler
+    - agent==0.1.2
+    - Pygments==2.0.2
+    - pydocx==0.7.0
+    - Pillow==2.8.2
+    - nbconvert==4.2.0
+    - nbformat==4.1.0
+    - traitlets==4.2.2
+    - jsonschema==2.4.0
+    - jinja2==2.7.3
+    - mistune==0.7
+    - docutils==0.12
+    - pandas==0.17.1
+    - git+https://github.com/icereval/xlrd.git
+    - markdown==2.6.2
+    - certifi==2015.4.28

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,2 @@
+conda:
+    file: environment.yml


### PR DESCRIPTION
# Purpose

Upgrade invoke to 0.13.0 and write a work around so mfr can use python 3 with read-the-docs.

# Changes

Additional config files for read the docs, removes references to non-existent LaTex files.

# Side Effects

None that I know of.

# Ticket

https://openscience.atlassian.net/browse/SVCS-123