### PR TITLE
[SVCS-218] Test MFR compatibility with python 3.5.3 and document

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@
 
 A Python package for rendering files to HTML via an embeddable iframe.
 
+### Compatibility
+
+The MFR is compatible with Python 3.5, 3.5.3 and 3.6 
+
+
 ### Documentation
 
 Documentation available at: http://modular-file-renderer.readthedocs.io/en/latest/
@@ -80,11 +85,14 @@ invoke test
 
 ### Known Issues
 
-Running invoke install -d with setuptools v31 can break waterbutler.  The symptom error message is: "AttributeError:
+ - Running invoke install -d with setuptools v31 can break waterbutler.  The symptom error message is: "AttributeError:
 module 'mfr' has no attribute '__version__'".  If you encounter this, you will need to remove the file
 mfr-nspkg.pth from your virtualenv directory, run `pip install setuptools==30.4.0`, then re-run `invoke install -d`.
 
-#
+- The error `    def create_default_context(purpose=ssl.Purpose.SERVER_AUTH, *, cafile=None, capath=None, cadata=None):
+                                                                 ^
+SyntaxError: invalid syntax` can be fixed by restarting your virtual environment, the problem should not reoccur. 
+
 
 ### Create your own module
 


### PR DESCRIPTION
# Purpose

See if MFR works well with updated asyncio functions.

# Changes

Adds Known Issue to the docs and a compatibility message stating compatibility.

# Side Effects

None 

# Ticket

https://openscience.atlassian.net/projects/SVCS/issues/SVCS-218