### PR TITLE
[SVCS-241][SVCS-53] Add maximum file size limit for rendering files with certain extensions.

### DIFF
--- a/mfr/core/exceptions.py
+++ b/mfr/core/exceptions.py
@@ -145,6 +145,14 @@ class MetadataError(ProviderError):
             'response': self.response
         }])
 
+class TooBigToRenderError(ProviderError):
+
+    __TYPE = 'too_big_to_render'
+
+    def __init__(self, message, *args, code: int=400, **kwargs):
+        super().__init__(message, *args, code=code, **kwargs)
+        self.attr_stack.append([self.__TYPE, {}])
+
 
 class DriverManagerError(PluginError):
 

--- a/mfr/core/utils.py
+++ b/mfr/core/utils.py
@@ -96,3 +96,10 @@ def make_renderer(name, metadata, file_path, url, assets_url, export_url):
                 'export_url': export_url,
             }
         )
+
+def sizeof_fmt(num, suffix='B'):
+    for unit in ['','Ki','Mi','Gi','Ti','Pi','Ei','Zi']:
+        if abs(num) < 1024.0:
+            return "%3.1f%s%s" % (num, unit, suffix)
+        num /= 1024.0
+    return "%.1f%s%s" % (num, 'Yi', suffix)

--- a/mfr/core/utils.py
+++ b/mfr/core/utils.py
@@ -98,8 +98,8 @@ def make_renderer(name, metadata, file_path, url, assets_url, export_url):
         )
 
 def sizeof_fmt(num, suffix='B'):
-    for unit in ['','Ki','Mi','Gi','Ti','Pi','Ei','Zi']:
+    for unit in ['', 'Ki', 'Mi', 'Gi', 'Ti', 'Pi', 'Ei', 'Zi']:
         if abs(num) < 1024.0:
-            return "%3.1f%s%s" % (num, unit, suffix)
+            return '%3.1f%s%s' % (num, unit, suffix)
         num /= 1024.0
-    return "%.1f%s%s" % (num, 'Yi', suffix)
+    return '%.1f%s%s' % (num, 'Yi', suffix)

--- a/mfr/core/utils.py
+++ b/mfr/core/utils.py
@@ -98,8 +98,8 @@ def make_renderer(name, metadata, file_path, url, assets_url, export_url):
         )
 
 def sizeof_fmt(num, suffix='B'):
-    for unit in ['', 'Ki', 'Mi', 'Gi', 'Ti', 'Pi', 'Ei', 'Zi']:
-        if abs(num) < 1024.0:
+    for unit in ['', 'K', 'M', 'G', 'T', 'P', 'E', 'Z']:
+        if abs(num) < 1000.0:
             return '%3.1f%s%s' % (num, unit, suffix)
-        num /= 1024.0
-    return '%.1f%s%s' % (num, 'Yi', suffix)
+        num /= 1000.0
+    return '%.1f%s%s' % (num, 'Y', suffix)

--- a/mfr/extensions/tabular/exceptions.py
+++ b/mfr/extensions/tabular/exceptions.py
@@ -33,14 +33,6 @@ class TableTooBigError(TabularRendererError):
         super().__init__(message, *args, code=code, **kwargs)
         self.attr_stack.append([self.__TYPE, {}])
 
-class TooBigToRenderError(TabularRendererError):
-
-    __TYPE = 'tabular_too_big_to_render'
-
-    def __init__(self, message, *args, code: int=400, **kwargs):
-        super().__init__(message, *args, code=code, **kwargs)
-        self.attr_stack.append([self.__TYPE, {}])
-
 
 class UnexpectedFormattingError(TabularRendererError):
 

--- a/mfr/extensions/tabular/exceptions.py
+++ b/mfr/extensions/tabular/exceptions.py
@@ -33,6 +33,14 @@ class TableTooBigError(TabularRendererError):
         super().__init__(message, *args, code=code, **kwargs)
         self.attr_stack.append([self.__TYPE, {}])
 
+class TooBigToRenderError(TabularRendererError):
+
+    __TYPE = 'tabular_too_big_to_render'
+
+    def __init__(self, message, *args, code: int=400, **kwargs):
+        super().__init__(message, *args, code=code, **kwargs)
+        self.attr_stack.append([self.__TYPE, {}])
+
 
 class UnexpectedFormattingError(TabularRendererError):
 

--- a/mfr/providers/osf/provider.py
+++ b/mfr/providers/osf/provider.py
@@ -100,7 +100,7 @@ class OsfProvider(provider.BaseProvider):
 
         name, ext = os.path.splitext(metadata['data']['name'])
 
-        if  MAX_FILE_SIZE_TO_RENDER.get(ext) and metadata['data']['size'] > MAX_FILE_SIZE_TO_RENDER.get(ext):
+        if MAX_FILE_SIZE_TO_RENDER.get(ext) and metadata['data']['size'] > MAX_FILE_SIZE_TO_RENDER.get(ext):
             size = sizeof_fmt(MAX_FILE_SIZE_TO_RENDER.get(ext))
             raise TooBigToRenderError("This file exceeds with extention '{ext}' the size limit of {size}".format(**locals()))
 

--- a/mfr/providers/osf/provider.py
+++ b/mfr/providers/osf/provider.py
@@ -102,7 +102,8 @@ class OsfProvider(provider.BaseProvider):
 
         if MAX_FILE_SIZE_TO_RENDER.get(ext) and metadata['data']['size'] > MAX_FILE_SIZE_TO_RENDER.get(ext):
             size = sizeof_fmt(MAX_FILE_SIZE_TO_RENDER.get(ext))
-            raise TooBigToRenderError("This file exceeds with extension '{ext}' the size limit of {size}".format(**locals()))
+            raise TooBigToRenderError("This file with extension '{ext}' exceeds the size limit of {size} and will not "
+                                      "be rendered. To view this file download it and view it offline.".format(**locals()))
 
         content_type = metadata['data']['contentType'] or mimetypes.guess_type(metadata['data']['name'])[0]
         cleaned_url = furl.furl(download_url)

--- a/mfr/providers/osf/provider.py
+++ b/mfr/providers/osf/provider.py
@@ -102,7 +102,7 @@ class OsfProvider(provider.BaseProvider):
 
         if MAX_FILE_SIZE_TO_RENDER.get(ext) and metadata['data']['size'] > MAX_FILE_SIZE_TO_RENDER.get(ext):
             size = sizeof_fmt(MAX_FILE_SIZE_TO_RENDER.get(ext))
-            raise TooBigToRenderError("This file exceeds with extention '{ext}' the size limit of {size}".format(**locals()))
+            raise TooBigToRenderError("This file exceeds with extension '{ext}' the size limit of {size}".format(**locals()))
 
         content_type = metadata['data']['contentType'] or mimetypes.guess_type(metadata['data']['name'])[0]
         cleaned_url = furl.furl(download_url)

--- a/mfr/providers/osf/provider.py
+++ b/mfr/providers/osf/provider.py
@@ -13,7 +13,10 @@ from waterbutler.core import streams
 
 from mfr.core import exceptions
 from mfr.core import provider
+from mfr.core.utils import sizeof_fmt
 from mfr.providers.osf import settings
+from mfr.settings import MAX_FILE_SIZE_TO_RENDER
+from mfr.extensions.tabular.exceptions import TooBigToRenderError
 
 logger = logging.getLogger(__name__)
 
@@ -96,6 +99,11 @@ class OsfProvider(provider.BaseProvider):
         # }}
 
         name, ext = os.path.splitext(metadata['data']['name'])
+
+        if  MAX_FILE_SIZE_TO_RENDER.get(ext) and metadata['data']['size'] > MAX_FILE_SIZE_TO_RENDER.get(ext):
+            size = sizeof_fmt(MAX_FILE_SIZE_TO_RENDER.get(ext))
+            raise TooBigToRenderError("This file exceeds with extention '{ext}' the size limit of {size}".format(**locals()))
+
         content_type = metadata['data']['contentType'] or mimetypes.guess_type(metadata['data']['name'])[0]
         cleaned_url = furl.furl(download_url)
         for unneeded in OsfProvider.UNNEEDED_URL_PARAMS:

--- a/mfr/providers/osf/provider.py
+++ b/mfr/providers/osf/provider.py
@@ -16,7 +16,7 @@ from mfr.core import provider
 from mfr.core.utils import sizeof_fmt
 from mfr.providers.osf import settings
 from mfr.settings import MAX_FILE_SIZE_TO_RENDER
-from mfr.extensions.tabular.exceptions import TooBigToRenderError
+from mfr.core.exceptions import TooBigToRenderError
 
 logger = logging.getLogger(__name__)
 
@@ -99,11 +99,14 @@ class OsfProvider(provider.BaseProvider):
         # }}
 
         name, ext = os.path.splitext(metadata['data']['name'])
+        size = metadata['data']['size']
 
-        if MAX_FILE_SIZE_TO_RENDER.get(ext) and metadata['data']['size'] > MAX_FILE_SIZE_TO_RENDER.get(ext):
-            size = sizeof_fmt(MAX_FILE_SIZE_TO_RENDER.get(ext))
+        max_file_size = MAX_FILE_SIZE_TO_RENDER.get(ext)
+        if max_file_size and size and size > max_file_size:
+            size = sizeof_fmt(max_file_size)
             raise TooBigToRenderError("This file with extension '{ext}' exceeds the size limit of {size} and will not "
-                                      "be rendered. To view this file download it and view it offline.".format(**locals()))
+                                      "be rendered. To view this file download it and view it offline.".format(ext=ext,
+                                                                                                               size=size))
 
         content_type = metadata['data']['contentType'] or mimetypes.guess_type(metadata['data']['name'])[0]
         cleaned_url = furl.furl(download_url)

--- a/mfr/settings.py
+++ b/mfr/settings.py
@@ -84,6 +84,8 @@ PROJECT_CONFIG_PATH = '~/.cos'
 UNSUPPORTED_EXPORTER_MSG = 'Exporting of this file type is not currently supported.'
 UNSUPPORTED_RENDER_MSG = 'Viewing of this file type is not currently supported. Please download the file to view.'
 
+MAX_FILE_SIZE_TO_RENDER = {'csv' : 10000, '.xlsx' : 10}
+
 try:
     import colorlog  # noqa
     DEFAULT_FORMATTER = {

--- a/mfr/settings.py
+++ b/mfr/settings.py
@@ -84,7 +84,8 @@ PROJECT_CONFIG_PATH = '~/.cos'
 UNSUPPORTED_EXPORTER_MSG = 'Exporting of this file type is not currently supported.'
 UNSUPPORTED_RENDER_MSG = 'Viewing of this file type is not currently supported. Please download the file to view.'
 
-MAX_FILE_SIZE_TO_RENDER = {'csv': 10000, '.xlsx': 10}
+
+MAX_FILE_SIZE_TO_RENDER = {'csv': 100000, '.xlsx': 100000, '.tsv' : 100000, '.sav' : 100000, '.xls' : 100000}
 
 try:
     import colorlog  # noqa

--- a/mfr/settings.py
+++ b/mfr/settings.py
@@ -85,7 +85,7 @@ UNSUPPORTED_EXPORTER_MSG = 'Exporting of this file type is not currently support
 UNSUPPORTED_RENDER_MSG = 'Viewing of this file type is not currently supported. Please download the file to view.'
 
 
-MAX_FILE_SIZE_TO_RENDER = {'csv': 100000, '.xlsx': 100000, '.tsv': 100000, '.sav': 100000, '.xls': 100000}
+MAX_FILE_SIZE_TO_RENDER = {'.csv': 100000000, '.xlsx': 1000000000, '.tsv': 1000000000, '.sav': 1000000000, '.xls': 1000000000}
 
 try:
     import colorlog  # noqa

--- a/mfr/settings.py
+++ b/mfr/settings.py
@@ -85,7 +85,7 @@ UNSUPPORTED_EXPORTER_MSG = 'Exporting of this file type is not currently support
 UNSUPPORTED_RENDER_MSG = 'Viewing of this file type is not currently supported. Please download the file to view.'
 
 
-MAX_FILE_SIZE_TO_RENDER = {'csv': 100000, '.xlsx': 100000, '.tsv' : 100000, '.sav' : 100000, '.xls' : 100000}
+MAX_FILE_SIZE_TO_RENDER = {'csv': 100000, '.xlsx': 100000, '.tsv': 100000, '.sav': 100000, '.xls': 100000}
 
 try:
     import colorlog  # noqa

--- a/mfr/settings.py
+++ b/mfr/settings.py
@@ -84,7 +84,7 @@ PROJECT_CONFIG_PATH = '~/.cos'
 UNSUPPORTED_EXPORTER_MSG = 'Exporting of this file type is not currently supported.'
 UNSUPPORTED_RENDER_MSG = 'Viewing of this file type is not currently supported. Please download the file to view.'
 
-MAX_FILE_SIZE_TO_RENDER = {'csv' : 10000, '.xlsx' : 10}
+MAX_FILE_SIZE_TO_RENDER = {'csv': 10000, '.xlsx': 10}
 
 try:
     import colorlog  # noqa


### PR DESCRIPTION
# Purpose

Add maximum file size limit for rendering files with certain extensions.

# Changes

Adds new type of exception and a throws it when metadata indicates a file has exceeded the maximum size for it's extension.

# Side Effects

None that I know of

# Ticket

https://openscience.atlassian.net/browse/SVCS-241

Related to:

https://openscience.atlassian.net/browse/SVCS-53
https://openscience.atlassian.net/browse/SVCS-235

Figure (New Behavior):
<img width="1418" alt="screen shot 2017-02-02 at 10 10 19 am" src="https://cloud.githubusercontent.com/assets/9688518/22554914/e1502caa-e92f-11e6-90c0-62517c59eda7.png">
