### PR TITLE
[SVCS-235] MFR handle 'field too large' error more gracefully

### DIFF
--- a/mfr/extensions/tabular/render.py
+++ b/mfr/extensions/tabular/render.py
@@ -1,5 +1,6 @@
 import os
 import json
+import _csv
 
 from mako.lookup import TemplateLookup
 from mfr.core import extension
@@ -41,7 +42,14 @@ class TabularRenderer(extension.BaseRenderer):
         """
         self._renderer_tabular_metrics = {}
 
-        sheets = self._populate_data(fp, ext)
+        try:
+            sheets = self._populate_data(fp, ext)
+        except _csv.Error as e:
+            if any("field larger than field limit" in errorMsg for errorMsg in e.args):
+                raise exceptions.TabularRendererError('This file contains a field too large to render. '
+                                           'Please download and view it locally.')
+            else:
+                raise exceptions.TabularRendererError('_csv.Error: {}'.format(e))
 
         size = settings.SMALL_TABLE
         self._renderer_tabular_metrics['size'] = 'small'

--- a/mfr/extensions/tabular/render.py
+++ b/mfr/extensions/tabular/render.py
@@ -1,6 +1,5 @@
 import os
 import json
-import csv
 
 from mako.lookup import TemplateLookup
 from mfr.core import extension

--- a/mfr/extensions/tabular/render.py
+++ b/mfr/extensions/tabular/render.py
@@ -1,6 +1,6 @@
 import os
 import json
-import _csv
+import csv
 
 from mako.lookup import TemplateLookup
 from mfr.core import extension
@@ -42,14 +42,7 @@ class TabularRenderer(extension.BaseRenderer):
         """
         self._renderer_tabular_metrics = {}
 
-        try:
-            sheets = self._populate_data(fp, ext)
-        except _csv.Error as e:
-            if any("field larger than field limit" in errorMsg for errorMsg in e.args):
-                raise exceptions.TabularRendererError('This file contains a field too large to render. '
-                                           'Please download and view it locally.')
-            else:
-                raise exceptions.TabularRendererError('_csv.Error: {}'.format(e))
+        sheets = self._populate_data(fp, ext)
 
         size = settings.SMALL_TABLE
         self._renderer_tabular_metrics['size'] = 'small'


### PR DESCRIPTION
# Purpose 

Our csv tabular render chokes when a field is too large to be read by the underlying library: https://sentry.cos.io/share/issue/32312e36363838/ This makes ot show a  more informative error message.

# Changes

Catches error thrown by _csv library and display field limit error or other error caught by _csv

# Side Effect

None that I know of

# Ticket

https://openscience.atlassian.net/browse/SVCS-235

# Figure
New Message
<img width="1414" alt="screen shot 2017-02-09 at 3 44 29 pm" src="https://cloud.githubusercontent.com/assets/9688518/22802417/beacb79a-eede-11e6-8a47-604c546a1080.png">
