### PR TITLE
[hotfix][SVCS-257] Fix  MFR failing to render .ipynb files on prod

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,7 +3,6 @@
 -e git+https://github.com/centerforopenscience/aiohttpretty.git@0.0.2#egg=aiohttpretty
 colorlog==2.5.0
 flake8==3.0.4
-ipdb
 mccabe
 pydevd==0.0.6
 pyflakes

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,6 +3,7 @@
 -e git+https://github.com/centerforopenscience/aiohttpretty.git@0.0.2#egg=aiohttpretty
 colorlog==2.5.0
 flake8==3.0.4
+ipdb
 mccabe
 pydevd==0.0.6
 pyflakes

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ pydocx==0.7.0
 Pillow==2.8.2
 
 # IPython
-ipdb==0.10.2
+ipython==5.2.2
 nbconvert==4.2.0
 nbformat==4.1.0
 traitlets==4.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ pydocx==0.7.0
 Pillow==2.8.2
 
 # IPython
+ipdb==0.10.2
 nbconvert==4.2.0
 nbformat==4.1.0
 traitlets==4.2.2


### PR DESCRIPTION
# Purpose

Fix error where .ipynb files don't render using the MFR on production, but work locally.

# Changes

Change requirements.txt so IPython loads as part of main requirements.txt not  dev-requirements.txt 

# Side Effects

None that I know of.

# Ticket

https://openscience.atlassian.net/browse/SVCS-257