### PR TITLE
[SVCS-38] Fix .gdraw rendering

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         ],
         'mfr.exporters': [
             # google docs
-            '.gdraw = mfr.extensions.unoconv:UnoconvExporter',
+            '.gdraw = mfr.extensions.image:ImageExporter',
             '.gdoc = mfr.extensions.unoconv:UnoconvExporter',
             '.gsheet = mfr.extensions.unoconv:UnoconvExporter',
             '.gslides = mfr.extensions.unoconv:UnoconvExporter',


### PR DESCRIPTION
## Purpose

.gdraw render as broken links and this fixes that.

## Changes

Uses normal image renderer as opposed to unoconv render with the wrong exporter.

## Side Effects

None that I know of.

## Tickets

https://openscience.atlassian.net/browse/SVCS-38