### PR TITLE
Update furl dependency to fix bug #250

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiohttp==0.18.4
 chardet==2.3.0
-furl==0.4.2
+furl==0.5.7
 humanfriendly==2.1
 invoke==0.13.0
 mako==1.0.1


### PR DESCRIPTION
Updated requirement for furl package to a version greater than 0.4.2 (0.5.7) in order to fix bug #250.


CI build report here:
[https://travis-ci.org/rija/modular-file-renderer/builds/225183774](https://travis-ci.org/rija/modular-file-renderer/builds/225183774)

