### PR TITLE
Updated Dockerfile so that PID 1 is attached to a process supervisor …

### DIFF
--- a/circus.ini
+++ b/circus.ini
@@ -1,0 +1,18 @@
+[watcher:mfr]
+cmd =  /usr/local/bin/invoke server
+copy_env = True
+working_dir = /code
+stdout_stream.class = FileStream
+stdout_stream.filename = /var/log/mfr.stdout
+stdout_stream.time_format = %%Y-%%m-%%d %%H:%%M:%%S
+stdout_stream.max_bytes = 573741824
+stdout_stream.backup_count = 5
+stderr_stream.class = FileStream
+stderr_stream.filename = /var/log/mfr.stderr
+stderr_stream.time_format = %%Y-%%m-%%d %%H:%%M:%%S
+stderr_stream.max_bytes = 573741824
+stderr_stream.backup_count = 5
+
+
+[watcher:libreoffice]
+cmd = /usr/lib/libreoffice/program/soffice.bin --headless --invisible --nocrashreport --nodefault --nologo --nofirststartwizard --norestore --accept=socket,host=127.0.0.1,port=2002;urp;


### PR DESCRIPTION
**A proposed fix for #252** 

I've chosen Mozilla Circus as process manager because:
* as of time of writing, supervisord don't seem to work with python 3.*
* I had hard time with installing/configuring supervisord on Centos/Redhat installs
* Circus can manage both processes and sockets which could help productionize an mfr install behind WSGI servers

**changes:**

Added configuration file for Circus to allow circus to manage invoke server and headless Libre Office server processes cleanly
Copied MFR config file to mfr-test.json and waterbutler-test.json in the docker container to silence warnings and allow for in-container configuration
Moved the CMD and EXPOSE to the top of the Dockerfile to take advantage of the Docker build caching mechanism for iterative builds.