### PR TITLE
[SVCS-76] Track requests within OSF

### DIFF
--- a/mfr/server/handlers/core.py
+++ b/mfr/server/handlers/core.py
@@ -132,6 +132,7 @@ class BaseHandler(CorsMixin, tornado.web.RequestHandler, SentryMixin):
         )
 
         self.source_file_id = uuid.uuid4()
+        self.add_header('X-MFR-REQUEST-ID', str(uuid.uuid4()))
 
     async def write_stream(self, stream):
         try:


### PR DESCRIPTION
# Purpose

Dropbox and Github have a nice feature where they return request identifiers in their response headers. That way, when a request starts acting up you can contact their support with the ID. This enables MFR to do the same thing. Now we can verify a particular request made from the browser is the same one in our logs and more easily track inter-service requests if we want.

# Changes

Simply adds a uniquely generated id to the header "X-MFR-REQUEST-ID" when the request is being prepared.

# Side Effects
None that I know of.

# Ticket

https://openscience.atlassian.net/browse/SVCS-76