### PR TITLE
Catch KEEN_PRIVATE_PROJECT_ID is not defined

### DIFF
--- a/mfr/core/remote_logging.py
+++ b/mfr/core/remote_logging.py
@@ -17,7 +17,10 @@ logger = logging.getLogger(__name__)
 
 async def log_analytics(request, metrics, is_error=False):
     """Send events to Keen describing the action that occurred."""
-    if settings.KEEN_PRIVATE_PROJECT_ID is None:
+    try:
+        if settings.KEEN_PRIVATE_PROJECT_ID is None:
+            return
+    except:
         return
 
     keen_payload = copy.deepcopy(metrics)


### PR DESCRIPTION
In the default configuration is the value KEEN_PRIVATE_PROJECT_ID commented out, so if you run the code you get the exception "AttributeError: module 'mfr.server.settings' has no attribute 'KEEN_PRIVATE_PROJECT_ID'". 
This catches the exception.