### PR TITLE
[WIP] Fix issue rendering videos in local dockerized OSF [#SVCS-336]

### DIFF
--- a/mfr/extensions/video/render.py
+++ b/mfr/extensions/video/render.py
@@ -13,7 +13,7 @@ class VideoRenderer(extension.BaseRenderer):
         ]).get_template('viewer.mako')
 
     def render(self):
-        return self.TEMPLATE.render(base=self.assets_url, url=self.url)
+        return self.TEMPLATE.render(base=self.assets_url, url=self.metadata.download_url)
 
     @property
     def file_required(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,4 +8,4 @@
 [flake8]
 ignore = E501,E127,E128,E265,E301,E302,F403,E731
 max-line-length = 100
-exclude = .ropeproject,tests/*,src/*
+exclude = .ropeproject,tests/*,src/*,env,venv

--- a/tests/extensions/video/test_renderer.py
+++ b/tests/extensions/video/test_renderer.py
@@ -37,10 +37,10 @@ def renderer(metadata, file_path, url, assets_url, export_url):
 
 class TestVideoRenderer:
 
-    def test_render_video(self, renderer, url):
+    def test_render_video(self, renderer, metadata):
         body = renderer.render()
         assert '<video controls' in body
-        assert 'src="{}"'.format(url) in body
+        assert 'src="{}"'.format(metadata.download_url) in body
 
     def test_render_video_file_required(self, renderer):
         assert renderer.file_required is False


### PR DESCRIPTION
# Ticket
https://openscience.atlassian.net/browse/SVCS-336

# Purpose
MFR was unable to render videos locally, due to an issue where the URL required for servers to talk to each other (IP-based) was different from the URL used by the browser to talk to the server. ("localhost") This is a quirk of dockerized local development that does not affect staging or production use.

# Summary of changes
Fix inspired by the [PDB file renderer](https://github.com/abought/modular-file-renderer/blob/70b4c7f2d030eff5e59f340e999a325863bb2db2/mfr/extensions/pdb/render.py#L21-L21): tell the HTML tag to find the video at `metadata.download_url` instead of `url`. This value comes from [waterbutler](https://github.com/abought/modular-file-renderer/blob/1a319dc47051579e1f808944da178e0639a29a75/mfr/server/handlers/core.py#L120-L120).

Validity of this fix depends on waterbutler giving the right path even when MFR doesn't guess right.  (TODO verify)

TODO
- [ ] Investigate the above assumptions and report back
- [ ] BLOCKER- Still/ currently getting some 401 errors- investigate further. The URL change was only working temporarily due to a cached cookie in firefox

# Testing notes
Problem manifests when running via local docker. We expect that this change would not alter the behavior of videos in staging or production: they worked before and should work after.

The fix is specific to browsers, because when the video appeared to have a different address, the localhost cookie could not be sent. A dev could always have accessed the OSF via an IP-prefixed URL instead, but this is inconvenient and confusing.