### PR TITLE
[SVCS-129] Don't 500 when missing required query parameters

### DIFF
--- a/mfr/server/handlers/export.py
+++ b/mfr/server/handlers/export.py
@@ -25,7 +25,8 @@ class ExportHandler(core.BaseHandler):
 
         format = self.request.query_arguments.get('format', None)
         if not format:
-            raise InvalidParameters("Invalid Request: <your error message>")
+            raise InvalidParameters("Invalid Request: Url requires query parameter 'format' with"
+                                    " appropriate extension")
         # TODO: do we need to catch exceptions for decoding?
         self.format = format[0].decode('utf-8')
 

--- a/mfr/server/handlers/export.py
+++ b/mfr/server/handlers/export.py
@@ -1,14 +1,13 @@
-import os
 import asyncio
 import logging
+import os
 
-import waterbutler.core.streams
 from waterbutler.core.exceptions import InvalidParameters, DownloadError
+import waterbutler.core.streams
 
+from mfr.core import utils
 from mfr.server import settings
-from mfr.core import utils as utils
 from mfr.server.handlers import core
-
 
 logger = logging.getLogger(__name__)
 
@@ -24,10 +23,11 @@ class ExportHandler(core.BaseHandler):
 
         await super().prepare()
 
-        if self.request.query_arguments.get('format'):
-            self.format = self.request.query_arguments['format'][0].decode('utf-8')
-        else:
-            raise InvalidParameters("Url requires query parameter 'format' with appropriate extension")
+        format = self.request.query_arguments.get('format', None)
+        if not format:
+            raise InvalidParameters("Invalid Request: <your error message>")
+        # TODO: do we need to catch exceptions for decoding?
+        self.format = format[0].decode('utf-8')
 
         self.cache_file_id = '{}.{}'.format(self.metadata.unique_key, self.format)
 

--- a/tests/server/handlers/test_query_params.py
+++ b/tests/server/handlers/test_query_params.py
@@ -1,10 +1,9 @@
 import pytest
-from mfr.core.exceptions import ProviderError
+from http import HTTPStatus
 
 from tornado.httpclient import HTTPError
 from tests import utils
 from tornado import testing
-
 
 
 class TestRenderHandler(utils.HandlerTestCase):
@@ -15,14 +14,14 @@ class TestRenderHandler(utils.HandlerTestCase):
         with pytest.raises(HTTPError) as e:
             yield self.http_client.fetch(self.get_url('/export'), method='GET')
         assert e.value.message == 'Bad Request'
-        assert e.value.code == 400
+        assert e.value.code == HTTPStatus.BAD_REQUEST
 
         with pytest.raises(HTTPError) as e:
             yield self.http_client.fetch(self.get_url('/export?format=pdf'), method='GET')
         assert e.value.message == 'Bad Request'
-        assert e.value.code == 400
+        assert e.value.code == HTTPStatus.BAD_REQUEST
 
         with pytest.raises(HTTPError) as e:
             yield self.http_client.fetch(self.get_url('/export?url=http://test.com'), method='GET')
         assert e.value.message == 'Bad Request'
-        assert e.value.code == 400
+        assert e.value.code == HTTPStatus.BAD_REQUEST

--- a/tests/server/handlers/test_query_params.py
+++ b/tests/server/handlers/test_query_params.py
@@ -1,9 +1,10 @@
-import pytest
 from http import HTTPStatus
 
-from tornado.httpclient import HTTPError
-from tests import utils
+import pytest
 from tornado import testing
+from tornado.httpclient import HTTPError
+
+from tests import utils
 
 
 class TestRenderHandler(utils.HandlerTestCase):

--- a/tests/server/handlers/test_query_params.py
+++ b/tests/server/handlers/test_query_params.py
@@ -1,0 +1,28 @@
+import pytest
+from mfr.core.exceptions import ProviderError
+
+from tornado.httpclient import HTTPError
+from tests import utils
+from tornado import testing
+
+
+
+class TestRenderHandler(utils.HandlerTestCase):
+
+    @testing.gen_test
+    def test_format_url(self):
+
+        with pytest.raises(HTTPError) as e:
+            yield self.http_client.fetch(self.get_url('/export'), method='GET')
+        assert e.value.message == 'Bad Request'
+        assert e.value.code == 400
+
+        with pytest.raises(HTTPError) as e:
+            yield self.http_client.fetch(self.get_url('/export?format=pdf'), method='GET')
+        assert e.value.message == 'Bad Request'
+        assert e.value.code == 400
+
+        with pytest.raises(HTTPError) as e:
+            yield self.http_client.fetch(self.get_url('/export?url=http://test.com'), method='GET')
+        assert e.value.message == 'Bad Request'
+        assert e.value.code == 400


### PR DESCRIPTION
# Purpose 

Making an MFR export request without passing the format parameter causes a 500. It
should throw a 400 instead. There are probably other unhandled cases like this. Check for missing required query params and throw meaningful errors.

Effected Params are:
url
format

# Changes

Adds exception handling and unit tests to MFR.

# Ticket
https://openscience.atlassian.net/browse/SVCS-129