### PR TITLE
[RFR][SVCS-336]MFR issue: cannot render (videos, PDFs, or PDBs) locally when dockerized

### DIFF
--- a/mfr/extensions/pdb/render.py
+++ b/mfr/extensions/pdb/render.py
@@ -5,6 +5,7 @@ import json
 from mako.lookup import TemplateLookup
 
 from mfr.core import extension
+from mfr.extensions.utils import download_from_template
 from mfr.extensions.pdb import settings
 
 
@@ -15,10 +16,11 @@ class PdbRenderer(extension.BaseRenderer):
             os.path.join(os.path.dirname(__file__), 'templates')
         ]).get_template('viewer.mako')
 
+    @download_from_template
     def render(self):
         return self.TEMPLATE.render(
             base=self.assets_url,
-            url=self.metadata.download_url,
+            url=self.download_url.geturl(),
             options=json.dumps(settings.OPTIONS),
         )
 

--- a/mfr/extensions/pdb/render.py
+++ b/mfr/extensions/pdb/render.py
@@ -5,8 +5,8 @@ import json
 from mako.lookup import TemplateLookup
 
 from mfr.core import extension
-from mfr.extensions.utils import download_from_template
 from mfr.extensions.pdb import settings
+from mfr.extensions.utils import munge_url_for_localdev
 
 
 class PdbRenderer(extension.BaseRenderer):
@@ -16,7 +16,7 @@ class PdbRenderer(extension.BaseRenderer):
             os.path.join(os.path.dirname(__file__), 'templates')
         ]).get_template('viewer.mako')
 
-    @download_from_template
+    @munge_url_for_localdev
     def render(self):
         return self.TEMPLATE.render(
             base=self.assets_url,

--- a/mfr/extensions/pdf/render.py
+++ b/mfr/extensions/pdf/render.py
@@ -3,7 +3,7 @@ import os
 from mako.lookup import TemplateLookup
 
 from mfr.core import extension
-from mfr.extensions.utils import download_from_template
+from mfr.extensions.utils import munge_url_for_localdev
 
 
 class PdfRenderer(extension.BaseRenderer):
@@ -13,7 +13,7 @@ class PdfRenderer(extension.BaseRenderer):
             os.path.join(os.path.dirname(__file__), 'templates')
         ]).get_template('viewer.mako')
 
-    @download_from_template
+    @munge_url_for_localdev
     def render(self):
         return self.TEMPLATE.render(base=self.assets_url, url=self.download_url.geturl())
 

--- a/mfr/extensions/pdf/render.py
+++ b/mfr/extensions/pdf/render.py
@@ -3,6 +3,7 @@ import os
 from mako.lookup import TemplateLookup
 
 from mfr.core import extension
+from mfr.extensions.utils import download_from_template
 
 
 class PdfRenderer(extension.BaseRenderer):
@@ -12,8 +13,9 @@ class PdfRenderer(extension.BaseRenderer):
             os.path.join(os.path.dirname(__file__), 'templates')
         ]).get_template('viewer.mako')
 
+    @download_from_template
     def render(self):
-        return self.TEMPLATE.render(base=self.assets_url, url=self.metadata.download_url)
+        return self.TEMPLATE.render(base=self.assets_url, url=self.download_url.geturl())
 
     @property
     def file_required(self):

--- a/mfr/extensions/settings.py
+++ b/mfr/extensions/settings.py
@@ -1,0 +1,11 @@
+from mfr import settings
+
+config = settings.child('EXTENSION_CONFIG')
+
+# LOCAL_DEVELOPMENT must be set to true for extensions that produce a waterbutler URL in the
+# TEMPLATE to render, when using local docker development environment. Call will be coming from
+# browser instead of docker container.
+
+LOCAL_DEVELOPMENT = config.get_bool('LOCAL_DEVELOPMENT', 0)
+DOCKER_LOCAL_HOST = config.get('DOCKER_LOCAL_HOST', '192.168.168.167')
+LOCAL_HOST = config.get('LOCAL_HOST', 'localhost')

--- a/mfr/extensions/utils.py
+++ b/mfr/extensions/utils.py
@@ -1,0 +1,22 @@
+from urllib.parse import urlparse, parse_qs, urlencode
+from mfr.extensions import settings
+
+
+def download_from_template(func):
+    """
+    Check if LOCAL_DEVELOPMENT and if so
+    Replace the docker domain with localhost (for use in local development).
+    e.g. http://localhost:7777/foo/bar => http://192.168.168.167:7777/foo/bar
+    """
+    def wrapper(self):
+        download_url = urlparse(self.metadata.download_url)
+        if (settings.LOCAL_DEVELOPMENT and download_url.hostname == settings.DOCKER_LOCAL_HOST):
+            query_dict = parse_qs(download_url.query, keep_blank_values=True)
+            query_dict.pop('mode', None)
+            download_url = download_url._replace(query=urlencode(query_dict, doseq=True))
+            download_url = download_url._replace(
+                netloc="{}:{}".format(settings.LOCAL_HOST, download_url.port)
+            )
+        self.download_url = download_url
+        return func(self)
+    return wrapper

--- a/mfr/extensions/utils.py
+++ b/mfr/extensions/utils.py
@@ -1,21 +1,22 @@
 from urllib.parse import urlparse, parse_qs, urlencode
+
 from mfr.extensions import settings
 
 
-def download_from_template(func):
+def munge_url_for_localdev(func):
     """
-    Check if LOCAL_DEVELOPMENT and if so
-    Replace the docker domain with localhost (for use in local development).
-    e.g. http://localhost:7777/foo/bar => http://192.168.168.167:7777/foo/bar
+    If MFR is being run in a local development environment (i.e. LOCAL_DEVELOPMENT is True), we
+    need to replace the internal host (the one the backend services communicate on, default:
+    192.168.168.167) with the external host (the one the user provides, default: "localhost")
+    e.g. http://192.168.168.167:7777/foo/bar => http://localhost:7777/foo/bar
     """
     def wrapper(self):
         download_url = urlparse(self.metadata.download_url)
         if (settings.LOCAL_DEVELOPMENT and download_url.hostname == settings.DOCKER_LOCAL_HOST):
             query_dict = parse_qs(download_url.query, keep_blank_values=True)
-            query_dict.pop('mode', None)
-            download_url = download_url._replace(query=urlencode(query_dict, doseq=True))
             download_url = download_url._replace(
-                netloc="{}:{}".format(settings.LOCAL_HOST, download_url.port)
+                query=urlencode(query_dict, doseq=True),
+                netloc='{}:{}'.format(settings.LOCAL_HOST, download_url.port)
             )
         self.download_url = download_url
         return func(self)

--- a/mfr/extensions/video/render.py
+++ b/mfr/extensions/video/render.py
@@ -2,6 +2,7 @@ import os
 
 from mako.lookup import TemplateLookup
 
+from mfr.extensions.utils import download_from_template
 from mfr.core import extension
 
 
@@ -12,8 +13,9 @@ class VideoRenderer(extension.BaseRenderer):
             os.path.join(os.path.dirname(__file__), 'templates')
         ]).get_template('viewer.mako')
 
+    @download_from_template
     def render(self):
-        return self.TEMPLATE.render(base=self.assets_url, url=self.url)
+        return self.TEMPLATE.render(url=self.download_url.geturl())
 
     @property
     def file_required(self):

--- a/mfr/extensions/video/render.py
+++ b/mfr/extensions/video/render.py
@@ -2,8 +2,8 @@ import os
 
 from mako.lookup import TemplateLookup
 
-from mfr.extensions.utils import download_from_template
 from mfr.core import extension
+from mfr.extensions.utils import munge_url_for_localdev
 
 
 class VideoRenderer(extension.BaseRenderer):
@@ -13,7 +13,7 @@ class VideoRenderer(extension.BaseRenderer):
             os.path.join(os.path.dirname(__file__), 'templates')
         ]).get_template('viewer.mako')
 
-    @download_from_template
+    @munge_url_for_localdev
     def render(self):
         return self.TEMPLATE.render(url=self.download_url.geturl())
 

--- a/tests/extensions/video/test_renderer.py
+++ b/tests/extensions/video/test_renderer.py
@@ -40,7 +40,7 @@ class TestVideoRenderer:
     def test_render_video(self, renderer, url):
         body = renderer.render()
         assert '<video controls' in body
-        assert 'src="{}"'.format(url) in body
+        assert 'src="{}"'.format(metadata().download_url) in body
 
     def test_render_video_file_required(self, renderer):
         assert renderer.file_required is False


### PR DESCRIPTION
## Purpose:
In local development, those MFR extensions that create javascript links to WB files, must use localhost instead of 192.168.168.167. This is because the request will come from the browser instead of the MFR docker instance. 

Add catch for rendering in local development

## Changes:
Add EXTENSION settings for LOCAL_HOST and DOCKER_LOCAL_HOST
Add mfr.extension.utils.get_local_export_url to ...
    1. Switch DOCKER_LOCAL_HOST to LOCAL_HOST
    2. Remove "mode" parameter
For renderers pdb, pdf, and video:
    Check for DOCKER_LOCAL_HOST and call mfr.extension.utils.get_local_export_url

## Side effects
None

## Important
There is a [related PR](https://github.com/CenterForOpenScience/osf.io/pull/7740) That adds EXTENSION_CONFIG_LOCAL_DEVELOPMENT=1 to .docker-compose.mfr.env . Would be nice if the were merged together, though nothing bad would happen if they weren't. 

[#SVCS-336]

- [x] Create PR for OSF.io add this line to OSF.io .docker-compose.mfr.env ```EXTENSION_CONFIG_LOCAL_DEVELOPMENT=1```