### PR TITLE
[SVCS-355] Support coveralls to expose code coverage metrics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,3 +35,6 @@ before_cache:
 
 notifications:
   flowdock: 0221882cdda034c0e9ac2a0e766053dd
+
+after_success:
+  coveralls

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 `develop` Build Status: [![Build Status](https://travis-ci.org/CenterForOpenScience/modular-file-renderer.svg?branch=develop)](https://travis-ci.org/CenterForOpenScience/modular-file-renderer)
 
+[![Coverage Status](https://coveralls.io/repos/github/CenterForOpenScience/modular-file-renderer/badge.svg)](https://coveralls.io/github/CenterForOpenScience/modular-file-renderer)
+
 A Python package for rendering files to HTML via an embeddable iframe.
 
 ### Compatibility

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,7 @@
+## Constraints file for resolving conflicts across packages. Used to resolve issues with sub-dependencies of an actual requirement.
+##  (eg when python-coveralls indirectly requires a version of requests)
+## "Constraints files are requirements files that only control which version of a requirement is installed, not whether it is installed or not."
+##     See https://pip-python3.readthedocs.org/en/latest/user_guide.html#constraints-files
+
+# Newer version of requests throw an error when using the version of chardet we pin to; this causes issues for python-coveralls
+requests==2.14.2

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,4 +9,5 @@ pydevd==0.0.6
 pyflakes
 pytest==2.8.2
 pytest-cov==2.2.0
+python-coveralls==2.9.1
 pyzmq==14.4.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,4 +8,4 @@
 [flake8]
 ignore = E501,E127,E128,E265,E301,E302,F403,E731
 max-line-length = 100
-exclude = .ropeproject,tests/*,src/*
+exclude = .ropeproject,tests/*,src/*,env,venv

--- a/tasks.py
+++ b/tasks.py
@@ -3,6 +3,7 @@ import os
 from invoke import task
 
 WHEELHOUSE_PATH = os.environ.get('WHEELHOUSE')
+CONSTRAINTS_FILE = 'constraints.txt'
 
 
 def monkey_patch(ctx):
@@ -27,7 +28,7 @@ def monkey_patch(ctx):
 @task
 def wheelhouse(ctx, develop=False):
     req_file = 'dev-requirements.txt' if develop else 'requirements.txt'
-    cmd = 'pip wheel --find-links={} -r {} --wheel-dir={}'.format(WHEELHOUSE_PATH, req_file, WHEELHOUSE_PATH)
+    cmd = 'pip wheel --find-links={} -r {} --wheel-dir={} -c {}'.format(WHEELHOUSE_PATH, req_file, WHEELHOUSE_PATH, CONSTRAINTS_FILE)
     ctx.run(cmd, pty=True)
 
 
@@ -35,7 +36,7 @@ def wheelhouse(ctx, develop=False):
 def install(ctx, develop=False):
     ctx.run('python setup.py develop')
     req_file = 'dev-requirements.txt' if develop else 'requirements.txt'
-    cmd = 'pip install --upgrade -r {}'.format(req_file)
+    cmd = 'pip install --upgrade -r {} -c {}'.format(req_file, CONSTRAINTS_FILE)
 
     if WHEELHOUSE_PATH:
         cmd += ' --no-index --find-links={}'.format(WHEELHOUSE_PATH)


### PR DESCRIPTION
Similar to https://github.com/CenterForOpenScience/waterbutler/pull/223

Ticket: https://openscience.atlassian.net/browse/SVCS-355

# Purpose
Encourage higher unit test coverage by supporting a badging/reporting service to make code coverage metrics more visible to developers.

Specifically, this activates `coveralls.io`, a service that COS has also used for projects such as `ember-osf`.

# Future improvements
This does not modify the existing reporting scheme, only the way in which those reports are surfaced to developers during the review / development process. Once we have experimented with these reports we may wish to change how or what is measured.

# Deployment notes
This requires turning something on at `coveralls.io`, which must be done by someone with write access to the repo, separate from merging this code.

# Testing notes
Developer facing change; no external changes needed.
