### PR TITLE
Add CI for Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 
 python:
   - "3.5"
+  - "3.6"
 
 sudo: false
 


### PR DESCRIPTION
Spiritual cousin of: 
Ticket: https://openscience.atlassian.net/browse/SVCS-354
https://github.com/CenterForOpenScience/waterbutler/pull/231

# Purpose
Run CI against multiple supported python versions, so that our claimed support range is verified automatically on every new pull request.

Unlike the related ticket, MFR ran just fine without extra help/ changes to dependencies, so this change should have fewer impacts.

# Testing notes
This will not change our production configuration and therefore would not trigger any user-facing QA- it is just a developer facing change.