### PR TITLE
[SVCS-287] Make Iframes scrollable for IE11

### DIFF
--- a/mfr/server/static/js/mfr.js
+++ b/mfr/server/static/js/mfr.js
@@ -80,6 +80,8 @@
             self.pymParent.iframe.setAttribute('allowfullscreen', '');
             self.pymParent.iframe.setAttribute('webkitallowfullscreen', '');
             self.pymParent.iframe.setAttribute('scrolling', 'yes');
+            self.pymParent.iframe.setAttribute('horizontalscrolling', 'yes');
+            self.pymParent.iframe.setAttribute('verticalscrolling', 'yes');
 
             self.pymParent.el.appendChild(self.spinner);
             $(self.pymParent.iframe).load(function () {


### PR DESCRIPTION
## Purpose

The MFR Iframe currently isn't scrollable in IE11 this fix solves that,

## Change

Changes iframe attribute to allow scrolling.

## Side Effect

None that I know of

## Ticket

https://openscience.atlassian.net/browse/SVCS-287 