### PR TITLE
[SVCS-423] Links in pdfs should no longer open in the iframe.

### DIFF
--- a/mfr/extensions/pdf/templates/viewer.mako
+++ b/mfr/extensions/pdf/templates/viewer.mako
@@ -19,7 +19,7 @@ http://sourceforge.net/adobe/cmap/wiki/License/
 -->
 <html dir="ltr" mozdisallowselectionprint moznomarginboxes>
   <head>
-    <base href="${base}/web/">
+    <base href="${base}/web/" target="_blank">
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <meta name="google" content="notranslate">

--- a/mfr/server/static/js/mfr.js
+++ b/mfr/server/static/js/mfr.js
@@ -80,7 +80,7 @@
             self.pymParent.iframe.setAttribute('allowfullscreen', '');
             self.pymParent.iframe.setAttribute('webkitallowfullscreen', '');
             self.pymParent.iframe.setAttribute('scrolling', 'yes');
-            self.pymParent.iframe.setAttribute('sandbox', 'allow-scripts');
+            self.pymParent.iframe.setAttribute('sandbox', 'allow-scripts allow-popups');
 
             self.pymParent.el.appendChild(self.spinner);
             $(self.pymParent.iframe).on('load', function () {

--- a/tests/extensions/pdf/test_renderer.py
+++ b/tests/extensions/pdf/test_renderer.py
@@ -39,6 +39,6 @@ class TestPdfRenderer:
 
     def test_render_pdf(self, renderer, metadata, assets_url):
         body = renderer.render()
-        assert '<base href="{}/{}/web/">'.format(assets_url, 'pdf') in body
+        assert '<base href="{}/{}/web/" target="_blank">'.format(assets_url, 'pdf') in body
         assert '<div id="viewer" class="pdfViewer"></div>' in body
         assert 'DEFAULT_URL = \'{}\''.format(metadata.download_url) in body


### PR DESCRIPTION
Instead, they should open in a new tab/window

https://openscience.atlassian.net/browse/SVCS-423

## Purpose
Fix opening links in an iframe.
Update tests to match fix.

## Summary of changes
added default behavior of links to open in new tab, instead of on same page (in iframe)
Changed MFR tests to match this behavior.

## QA Notes
Open a pdf that has a link in it (example on jira ticket)
Click on the link
It should redirect you in a new tab, instead of in the iframe.

Mfr pdf tests should pass