### PR TITLE
Remove deprecated function call

### DIFF
--- a/mfr/server/static/js/mfr.js
+++ b/mfr/server/static/js/mfr.js
@@ -82,7 +82,7 @@
             self.pymParent.iframe.setAttribute('scrolling', 'yes');
 
             self.pymParent.el.appendChild(self.spinner);
-            $(self.pymParent.iframe).load(function () {
+            $(self.pymParent.iframe).on('load', function () {
                 self.pymParent.el.removeChild(self.spinner);
             });
 


### PR DESCRIPTION
.load is deprecated in jQuery. Use .on('load', ...) instead.

https://openscience.atlassian.net/browse/OSF-8380