### PR TITLE
[SVCS-467]Replaced old deprecated Mathjax cdn in Ipynb

### DIFF
--- a/mfr/extensions/ipynb/templates/viewer.mako
+++ b/mfr/extensions/ipynb/templates/viewer.mako
@@ -7,7 +7,7 @@
     ${body | n}
 </div>
 
-<script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js"></script>
 <script src="/static/js/mfr.js"></script>
 <script src="/static/js/mfr.child.js"></script>
 <script>


### PR DESCRIPTION

refs:  https://openscience.atlassian.net/browse/SVCS-467

## Purpose
Change mathjax cdn in the ipynb extension

## Summary of Changes
Changed mathajx cdn to a non deprecated one. 

## QA Notes:
There is a ipynb file with mathjax in it on the jira ticket. The mathjax should render correctly, and not as garble. 