### PR TITLE
[OSF-8638] Fix jquery 3 compatibility

### DIFF
--- a/mfr/server/static/js/mfr.js
+++ b/mfr/server/static/js/mfr.js
@@ -82,7 +82,7 @@
             self.pymParent.iframe.setAttribute('scrolling', 'yes');
 
             self.pymParent.el.appendChild(self.spinner);
-            $(self.pymParent.iframe).load(function () {
+            $(self.pymParent.iframe).on('load', function () {
                 self.pymParent.el.removeChild(self.spinner);
             });
 


### PR DESCRIPTION
Same as #276 , now as a hotfix.

.load is changed in jQuery 3. Use .on('load', ...) instead.

https://openscience.atlassian.net/browse/OSF-8638

This is backwards-compatible with older jQuery versions.