### PR TITLE
[SVCS-480] Update CONTRIBUTING and README for Change in ALLOWED_PROVIDER_DOMAINS

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -107,12 +107,12 @@ Manual Local Testing
 
 To make sure a new renderer is functioning properly, it's recommended that you try to render a file of that type locally. 
 
-First, change the default provider to HTTP (in `/mfr/server/settings.py`) and update the provider domain whitelist:
+First, change the default provider to HTTP (in `/mfr/server/settings.py`) and update the provider domain in ALLOWED_PROVIDER_DOMAINS whitelist (a space separated string.):
 
 .. code-block:: python
 
     PROVIDER_NAME = config.get('PROVIDER_NAME', 'http')
-    ALLOWED_PROVIDER_DOMAINS = config.get('ALLOWED_PROVIDER_DOMAINS', ['http://localhost:8000/'])
+    ALLOWED_PROVIDER_DOMAINS = config.get('ALLOWED_PROVIDER_DOMAINS', 'http://localhost:5000/ http://localhost:7777')
 
 	
 

--- a/README.md
+++ b/README.md
@@ -53,12 +53,12 @@ MFR configuration is done through a JSON file (`mfr-test.json`) that lives in th
 mkdir ~/.cos
 ```
 
-The defaults should suffice for most local testing.  If you're running the OSF on something other than `http://localhost:5000/`, you'll need to update the `ALLOWED_PROVIDER_DOMAINS` settings value:
+The defaults should suffice for most local testing.  If you're running the OSF.io or Waterbutler on something other than `http://localhost:5000/` and `http://localhost:7777/`, you'll need to update the `ALLOWED_PROVIDER_DOMAINS` settings value. `ALLOWED_PROVIDER_DOMAINS` is a list formatted as a space separated string. This allows for setting as an environment variable in OSF.io `.docker-compose.mfr.env`. Docker compose will not handle passing a python list as an environment variable to the underlying docker container.:
 
 ```json
 {
   "SERVER_CONFIG": {
-    "ALLOWED_PROVIDER_DOMAINS": ["http://localhost:9999/"]
+    "ALLOWED_PROVIDER_DOMAINS": "http://my_osf:5001/ http://my_wb:7778/"
   }
 }
 ```


### PR DESCRIPTION
Changes:
Update README.md and CONTRIBUTING.rst to reflect change in ALLOWED_PROVIDER_DOMAINS

ALLOWED_PROVIDER_DOMAINS was a python list.
Now a list formatted as a space separated string.

Thank you @jonathon-love for pointing out this mistake and taking the
time to submit a PR. Would have excepted the PR but needed to add an
explanation for the change.