### PR TITLE
[SVCS-507] Fix tabular renderer ext matching error

### DIFF
--- a/mfr/extensions/tabular/render.py
+++ b/mfr/extensions/tabular/render.py
@@ -63,7 +63,7 @@ class TabularRenderer(extension.BaseRenderer):
         :param ext: file extension
         :return: tuple of column headers and row data
         """
-        function_preference = settings.LIBS.get(ext)
+        function_preference = settings.LIBS.get(ext.lower())
 
         for function in function_preference:
             try:


### PR DESCRIPTION
refs: https://openscience.atlassian.net/browse/SVCS-507

## Purpose
If a tabular file extension was uppercased anywhere, it would throw an error. This changes allows the library matching function to ignore casing and find the proper function to render a file.

## Summary of Changes
function_preference is now found from extension.lower() instead of just the extension

## QA/Test Notes

There are 2 files on the ticket to test this with. Before changes, they should cause an error. With this change, they should render normally. 