### PR TITLE
[SVCS-528] Let WB know a request is coming from MFR

### DIFF
--- a/mfr/server/handlers/core.py
+++ b/mfr/server/handlers/core.py
@@ -104,6 +104,8 @@ class BaseHandler(CorsMixin, tornado.web.RequestHandler, SentryMixin):
 
         try:
             self.url = self.request.query_arguments['url'][0].decode('utf-8')
+            # TODO should probably use furl here, but maybe wait till after furl is upgraded
+            self.url += '&mfr=true'
         except KeyError:
             raise exceptions.ProviderError(
                 '"url" is a required argument.',

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ setup(
         'mfr.exporters': [
             # google docs
             '.gdraw = mfr.extensions.image:ImageExporter',
-            '.gdoc = mfr.extensions.unoconv:UnoconvExporter',
             '.gsheet = mfr.extensions.unoconv:UnoconvExporter',
             '.gslides = mfr.extensions.unoconv:UnoconvExporter',
 
@@ -658,7 +657,6 @@ setup(
 
             # google docs
             '.gdraw = mfr.extensions.image:ImageRenderer',
-            '.gdoc = mfr.extensions.unoconv:UnoconvRenderer',
             '.gsheet = mfr.extensions.tabular:TabularRenderer',
             '.gslides = mfr.extensions.unoconv:UnoconvRenderer',
 
@@ -690,6 +688,7 @@ setup(
 
             # pdf
             '.pdf = mfr.extensions.pdf:PdfRenderer',
+            '.gdoc = mfr.extensions.pdf:PdfRenderer',
 
             # rst
             '.rst = mfr.extensions.rst:RstRenderer',


### PR DESCRIPTION
## This ticket MUST be merged after its Waterbutler counterpart
<!-- Use the following format for the title of the Pull Request:

    [Status] [Ticket] Title

    - For PR ready for review, no need for status
    - For PR in progress, use [WIP]
    - For PR on hold, use [HOLD]
-->

<!-- Before submit your Pull Request, make sure you picked the right branch:

    - For hotfixes, select "master" as the target branch
    - For new features and improvements, select "develop" as the target branch
-->

<!-- For security related tickets, talk with the team lead before submit your PR -->

## Ticket
https://openscience.atlassian.net/browse/SVCS-528

Related Waterbutler counterpart PR:  https://github.com/CenterForOpenScience/waterbutler/pull/290

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/SVCS-1234 -->

## Purpose

<!-- Describe the purpose of your changes -->

## Changes
Append a `mfr` query param to WB urls to let it know the request is coming from WB
Move .gdoc extension from unoconv renderer/exporter to pdf renderer

<!-- Briefly describe or list your changes  -->

## Side effects
As long as the `mfr` query param is in effect, none
<!-- Any possible side effects? -->

## QA Notes
This must be tested with its WB counterpart to have any effect.

<!-- If applicable, briefly describe how QA should test this ticket/PR -->

## Deployment Notes

<!-- Any special configurations for deployment? -->
