### PR TITLE
[SVCS-159] Add renderer/exporter names to cached files

### DIFF
--- a/mfr/core/utils.py
+++ b/mfr/core/utils.py
@@ -1,3 +1,4 @@
+import pkg_resources
 from stevedore import driver
 
 from mfr.core import exceptions
@@ -96,6 +97,46 @@ def make_renderer(name, metadata, file_path, url, assets_url, export_url):
                 'export_url': export_url,
             }
         )
+
+def get_renderer_name(name):
+    """ Return the name of the renderer used for a certain file extension.
+
+    :param str name: The name of the extension to get the renderer name for. (.jpg, .docx, etc)
+
+    :rtype : `str`
+    """
+
+    # This can give back empty tuples
+    try:
+        entry_attrs = pkg_resources.iter_entry_points(group='mfr.renderers', name=name)
+
+    # ep.attrs is a tuple of attributes. There should only ever be one or `None`.
+    # None case occurs when trying to render an unsupported file type
+    # entry_attrs is an itrable object, so we turn into a list to index it
+        return list(entry_attrs)[0].attrs[0]
+
+    # This means the file type is not supported. Just return the blank string so `make_renderers` can
+    # log a real exception with all the variables and names it has
+    except IndexError:
+        return ''
+
+def get_exporter_name(name):
+    """ Return the name of the exporter used for a certain file extension.
+
+    :param str name: The name of the extension to get the exporter name for. (.jpg, .docx, etc)
+
+    :rtype : `str`
+    """
+
+    # `make_renderer` should have already caught if an extension doesn't exist.
+
+    # should be a list of length one, since we don't have multiple entrypoints per group
+    entry_attrs = pkg_resources.iter_entry_points(group='mfr.exporters', name=name)
+
+    # ep.attrs is a tuple of attributes. There should only ever be one or `None`.
+    # For our case however there shouldn't be `None`
+    return list(entry_attrs)[0].attrs[0]
+
 
 def sizeof_fmt(num, suffix='B'):
     for unit in ['', 'K', 'M', 'G', 'T', 'P', 'E', 'Z']:

--- a/mfr/core/utils.py
+++ b/mfr/core/utils.py
@@ -112,7 +112,7 @@ def get_renderer_name(name):
 
     # ep.attrs is a tuple of attributes. There should only ever be one or `None`.
     # None case occurs when trying to render an unsupported file type
-    # entry_attrs is an itrable object, so we turn into a list to index it
+    # entry_attrs is an iterable object, so we turn into a list to index it
         return list(entry_attrs)[0].attrs[0]
 
     # This means the file type is not supported. Just return the blank string so `make_renderers` can

--- a/mfr/server/handlers/export.py
+++ b/mfr/server/handlers/export.py
@@ -42,7 +42,7 @@ class ExportHandler(core.BaseHandler):
 
         self.output_file_id = '{}.{}'.format(self.source_file_path.name, self.format)
         self.output_file_path = await self.local_cache_provider.validate_path(
-            '/export/{}.{}'.format(self.output_file_id, self.exporter_name)
+            '/export/{}'.format(self.output_file_id)
         )
         self.metrics.merge({
             'output_file': {

--- a/mfr/server/handlers/export.py
+++ b/mfr/server/handlers/export.py
@@ -29,11 +29,12 @@ class ExportHandler(core.BaseHandler):
                                     " appropriate extension")
         # TODO: do we need to catch exceptions for decoding?
         self.format = format[0].decode('utf-8')
+        self.exporter_name = utils.get_exporter_name(self.metadata.ext)
 
         self.cache_file_id = '{}.{}'.format(self.metadata.unique_key, self.format)
 
         self.cache_file_path = await self.cache_provider.validate_path(
-            '/export/{}'.format(self.cache_file_id)
+            '/export/{}.{}'.format(self.cache_file_id, self.exporter_name)
         )
         self.source_file_path = await self.local_cache_provider.validate_path(
             '/export/{}'.format(self.source_file_id)
@@ -41,7 +42,7 @@ class ExportHandler(core.BaseHandler):
 
         self.output_file_id = '{}.{}'.format(self.source_file_path.name, self.format)
         self.output_file_path = await self.local_cache_provider.validate_path(
-            '/export/{}'.format(self.output_file_id)
+            '/export/{}.{}'.format(self.output_file_id, self.exporter_name)
         )
         self.metrics.merge({
             'output_file': {

--- a/mfr/server/handlers/render.py
+++ b/mfr/server/handlers/render.py
@@ -24,9 +24,11 @@ class RenderHandler(core.BaseHandler):
 
         await super().prepare()
 
+        self.renderer_name = utils.get_renderer_name(self.metadata.ext)
+
         self.cache_file_id = self.metadata.unique_key
         self.cache_file_path = await self.cache_provider.validate_path(
-            '/render/{}'.format(self.cache_file_id)
+            '/render/{}.{}'.format(self.cache_file_id, self.renderer_name)
         )
         self.source_file_path = await self.local_cache_provider.validate_path(
             '/render/{}'.format(self.source_file_id)

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -1,0 +1,39 @@
+import pytest
+import pkg_resources
+
+from mfr.core import utils as mfr_utils
+
+
+class TestGetRendererName:
+
+    def test_get_renderer_name_explicit_assertions(self):
+        assert mfr_utils.get_renderer_name('.jpg') == 'ImageRenderer'
+        assert mfr_utils.get_renderer_name('.txt') == 'CodePygmentsRenderer'
+        assert mfr_utils.get_renderer_name('.xlsx') == 'TabularRenderer'
+        assert mfr_utils.get_renderer_name('.odt') == 'UnoconvRenderer'
+        assert mfr_utils.get_renderer_name('.pdf') == 'PdfRenderer'
+
+    def test_get_renderer_name(self):
+        entry_points = pkg_resources.iter_entry_points(group='mfr.renderers')
+        for ep in entry_points:
+            expected = ep.attrs[0]
+            assert mfr_utils.get_renderer_name(ep.name) == expected
+
+    def test_get_renderer_name_no_entry_point(self):
+            assert mfr_utils.get_renderer_name('jpg') == ''
+
+class TestGetExporterName:
+
+    def test_get_exporter_name_explicit_assertions(self):
+        assert mfr_utils.get_exporter_name('.jpg') == 'ImageExporter'
+        assert mfr_utils.get_exporter_name('.odt') == 'UnoconvExporter'
+
+    def test_get_exporter_name(self):
+        entry_points = pkg_resources.iter_entry_points(group='mfr.exporters')
+        for ep in entry_points:
+            expected = ep.attrs[0]
+            assert mfr_utils.get_exporter_name(ep.name) == expected
+
+    def test_get_exporter_name_no_entry_point(self):
+        with pytest.raises(IndexError):
+            mfr_utils.get_exporter_name('jpg')


### PR DESCRIPTION
<!-- Use the following format for the title of the Pull Request:

    [Status] [Ticket] Title

    - For PR ready for review, no need for status
    - For PR in progress, use [WIP]
    - For PR on hold, use [HOLD]
-->

<!-- Before submit your Pull Request, make sure you picked the right branch:

    - For hotfixes, select "master" as the target branch
    - For new features and improvements, select "develop" as the target branch
-->

<!-- For security related tickets, talk with the team lead before submit your PR -->

## Ticket
https://openscience.atlassian.net/browse/SVCS-159
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/SVCS-1234 -->

## Purpose
Add renderer name to cached files
Add exporter name to cached files
<!-- Describe the purpose of your changes -->

## Changes
Added renderer to cached renderer files
Added exporter name to cached exported files
Added tests for changes
<!-- Briefly describe or list your changes  -->

## Side effects
Should be none

<!-- Any possible side effects? -->

## QA Notes
In order to test this locally, you need to turn MFR caching on: https://github.com/CenterForOpenScience/modular-file-renderer/blob/develop/mfr/server/settings.py#L28

Once this is on, in your logs you will see the caching messages, and it will show you the names of the cached files as well. 

The tests do not directly test this change in action, instead it tests to make sure that the added `get_exporter_name` and `get_renderer_name` return the proper values.



<!-- If applicable, briefly describe how QA should test this ticket/PR -->

## Deployment Notes
Some things to note: While renderer/exporter names have been added to cached files, this isn't always indicative of which files should be cleared when changes are made to a specific renderer.

For instance a cached .docx file will have `.UnoconvRenderer` at the end of it, but it is rendered by both the `.UnoconvRenderer` and the `PdfRenderer`. 

<!-- Any special configurations for deployment? -->
