### PR TITLE
[] [] Don't try to remove the temporary dir on the first install

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 
--e git+https://github.com/centerforopenscience/aiohttpretty.git@0.0.2#egg=aiohttpretty
+git+https://github.com/centerforopenscience/aiohttpretty.git@0.0.2#egg=aiohttpretty
 beautifulsoup4
 colorlog==2.5.0
 flake8==3.0.4


### PR DESCRIPTION
## Purpose

Running `docker-compose up mfr_requirements` fails because it waits for user interaction. Removing `-e` lets pip install aiohttppretty without failing because pip doesn't know what to do.

## Changes

Remove the `-e` flag from the requirements file

## Side effects

This flag looks like its been here since the dependency was first added, but there is no reason stated. There may be a reason its there? If so we can look at `--ignore-installed` as an alternative

## QA Notes

Probably no.

## Deployment Notes

Probably no. This only affects dev environments.
