### PR TITLE
[No Ticket]  Update and disable aiohttpretty

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,8 @@
 -r requirements.txt
 
-git+https://github.com/centerforopenscience/aiohttpretty.git@0.1.0#egg=aiohttpretty
+# aiohttpretty disabled due to no usage in MFR, re-enable when needed
+# git+https://github.com/centerforopenscience/aiohttpretty.git@0.1.0#egg=aiohttpretty
+
 beautifulsoup4
 colorlog==2.5.0
 flake8==3.0.4

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 
-git+https://github.com/centerforopenscience/aiohttpretty.git@0.0.2#egg=aiohttpretty
+git+https://github.com/centerforopenscience/aiohttpretty.git@0.1.0#egg=aiohttpretty
 beautifulsoup4
 colorlog==2.5.0
 flake8==3.0.4


### PR DESCRIPTION
## Ticket

No ticket or ticket to be created

## Purpose

This is a follow up PR for https://github.com/CenterForOpenScience/modular-file-renderer/pull/312 and https://github.com/CenterForOpenScience/waterbutler/pull/321. Instead of deleting it, I updated `aiohttpretty` and commented it out with a note in case we need it for tests in the future.

## Changes

As stated in **Purpose**

## Side effects

No

## QA Notes

No. This is a backend change for local development and travis only.

## Deployment Notes

No. Make sure that travis passes.
