### PR TITLE
[SVCS-159] Fix Extension Names in Renderer and Exporter

### DIFF
--- a/mfr/core/utils.py
+++ b/mfr/core/utils.py
@@ -98,6 +98,7 @@ def make_renderer(name, metadata, file_path, url, assets_url, export_url):
             }
         )
 
+
 def get_renderer_name(name):
     """ Return the name of the renderer used for a certain file extension.
 
@@ -108,7 +109,7 @@ def get_renderer_name(name):
 
     # This can give back empty tuples
     try:
-        entry_attrs = pkg_resources.iter_entry_points(group='mfr.renderers', name=name)
+        entry_attrs = pkg_resources.iter_entry_points(group='mfr.renderers', name=name.lower())
 
         # ep.attrs is a tuple of attributes. There should only ever be one or `None`.
         # None case occurs when trying to render an unsupported file type
@@ -119,6 +120,7 @@ def get_renderer_name(name):
     # can log a real exception with all the variables and names it has
     except IndexError:
         return ''
+
 
 def get_exporter_name(name):
     """ Return the name of the exporter used for a certain file extension.
@@ -131,8 +133,7 @@ def get_exporter_name(name):
     # `make_renderer` should have already caught if an extension doesn't exist.
 
     # should be a list of length one, since we don't have multiple entrypoints per group
-    entry_attrs = pkg_resources.iter_entry_points(group='mfr.exporters', name=name)
-
+    entry_attrs = pkg_resources.iter_entry_points(group='mfr.exporters', name=name.lower())
     # ep.attrs is a tuple of attributes. There should only ever be one or `None`.
     # For our case however there shouldn't be `None`
     return list(entry_attrs)[0].attrs[0]

--- a/mfr/core/utils.py
+++ b/mfr/core/utils.py
@@ -99,7 +99,7 @@ def make_renderer(name, metadata, file_path, url, assets_url, export_url):
         )
 
 
-def get_renderer_name(name):
+def get_renderer_name(name: str) -> str:
     """ Return the name of the renderer used for a certain file extension.
 
     :param str name: The name of the extension to get the renderer name for. (.jpg, .docx, etc)
@@ -107,22 +107,22 @@ def get_renderer_name(name):
     :rtype : `str`
     """
 
-    # This can give back empty tuples
-    try:
-        entry_attrs = pkg_resources.iter_entry_points(group='mfr.renderers', name=name.lower())
+    # `ep_iterator` is an iterable object. Must convert it to a `list` for access.
+    # `list()` can only be called once because the iterator moves to the end after conversion.
+    ep_iterator = pkg_resources.iter_entry_points(group='mfr.renderers', name=name.lower())
+    ep_list = list(ep_iterator)
 
-        # ep.attrs is a tuple of attributes. There should only ever be one or `None`.
-        # None case occurs when trying to render an unsupported file type
-        # entry_attrs is an iterable object, so we turn into a list to index it
-        return list(entry_attrs)[0].attrs[0]
-
-    # This means the file type is not supported. Just return the blank string so `make_renderers`
-    # can log a real exception with all the variables and names it has
-    except IndexError:
+    # Empty list indicates unsupported file type.
+    # Return a blank string and let `make_renderer()` handle it.
+    if len(ep_list) == 0:
         return ''
 
+    # If file type is supported, there must be only one element in the list.
+    assert len(ep_list) == 1
+    return ep_list[0].attrs[0]
 
-def get_exporter_name(name):
+
+def get_exporter_name(name: str) -> str:
     """ Return the name of the exporter used for a certain file extension.
 
     :param str name: The name of the extension to get the exporter name for. (.jpg, .docx, etc)
@@ -130,13 +130,14 @@ def get_exporter_name(name):
     :rtype : `str`
     """
 
-    # `make_renderer` should have already caught if an extension doesn't exist.
+    # `ep_iterator` is an iterable object. Must convert it to a `list` for access.
+    # `list()` can only be called once because the iterator moves to the end after conversion.
+    ep_iterator = pkg_resources.iter_entry_points(group='mfr.exporters', name=name.lower())
+    ep_list = list(ep_iterator)
 
-    # should be a list of length one, since we don't have multiple entrypoints per group
-    entry_attrs = pkg_resources.iter_entry_points(group='mfr.exporters', name=name.lower())
-    # ep.attrs is a tuple of attributes. There should only ever be one or `None`.
-    # For our case however there shouldn't be `None`
-    return list(entry_attrs)[0].attrs[0]
+    # `make_renderer()` is called before `make_exporter()` to ensure the file type is supported
+    assert len(ep_list) == 1
+    return ep_list[0].attrs[0]
 
 
 def sizeof_fmt(num, suffix='B'):

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -22,6 +22,7 @@ class TestGetRendererName:
     def test_get_renderer_name_no_entry_point(self):
             assert mfr_utils.get_renderer_name('jpg') == ''
 
+
 class TestGetExporterName:
 
     def test_get_exporter_name_explicit_assertions(self):
@@ -35,5 +36,5 @@ class TestGetExporterName:
             assert mfr_utils.get_exporter_name(ep.name) == expected
 
     def test_get_exporter_name_no_entry_point(self):
-        with pytest.raises(IndexError):
+        with pytest.raises(AssertionError):
             mfr_utils.get_exporter_name('jpg')


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/SVCS-159

## Purpose

https://github.com/CenterForOpenScience/modular-file-renderer/pull/296 breaks files of which the extension names are not lower case. This PR fix the issue.

## Changes

* `name` -> `name.lower()`
* Refactor `get_renderer_name()` and `get_exporter_name()`

## Side effects

No

## QA Notes

No

## Deployment Notes

No
