### PR TITLE
[SVCS-674][PLAT-218] Relay MFR header requests to WB

### DIFF
--- a/mfr/providers/osf/provider.py
+++ b/mfr/providers/osf/provider.py
@@ -125,6 +125,7 @@ class OsfProvider(provider.BaseProvider):
         """Download file from WaterButler, returning stream."""
         download_url = await self._fetch_download_url()
         headers = {settings.MFR_IDENTIFYING_HEADER: '1'}
+        headers.update(self.request.headers)
         response = await self._make_request('GET', download_url, allow_redirects=False, headers=headers)
 
         if response.status >= 400:


### PR DESCRIPTION
## Ticket
[SVCS-674](https://openscience.atlassian.net/browse/SVCS-674)
https://openscience.atlassian.net/browse/PLAT-709

## Purpose

Currently the MFR doesn't pass any useful information about the render back to the osf. This fix in conjunction with https://github.com/CenterForOpenScience/waterbutler/pull/324 will allow osf.io to receive information more information about how a file was received for analytics purposes.

## Changes

Relays MFRs Request headers to WB.

## Side effects

None that I know of.
