### PR TITLE
[SVCS-571] Fix Image Hi-Res and Zoom for IE

### DIFF
--- a/mfr/extensions/image/templates/viewer.mako
+++ b/mfr/extensions/image/templates/viewer.mako
@@ -103,7 +103,11 @@
                     ##      issue mentioned below.
                     ## 2.   Images are displayed in its actual size. No issue for all supported
                     ##      browsers.
-                    baseImage.wrap("<div></div>").parent().css("display", "inline-block");
+                    baseImage.wrap("<div></div>").parent().css({
+                        "display": "inline-block",
+                        "max-width": "100%",  // need to be explicit for IE
+                        "height": "auto"      // need to be explicit for IE
+                    });
                 } else {
                     ## Quirks: Chrome has a flickering bug when images are wrapped with `<div>` or
                     ## `<span>`.  During zoom the scroll bar keeps appearing and disappearing which


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/SVCS-571

## Purpose

Fix the issue that IE does not resize image to fit window size. 

## Changes

Explicitly set `"max-width": "100%"` and `"height": "auto"`.

## Side effects

No

## QA Notes

Test small, medium and large files on IE for this fix and on other supported browsers to make sure that nothing breaks.

## Deployment Notes

No
