### PR TITLE
[HotFix] [SVCS-676] Fix Memory Leak During CSV Rendering

### DIFF
--- a/mfr/extensions/tabular/libs/stdlib_tools.py
+++ b/mfr/extensions/tabular/libs/stdlib_tools.py
@@ -20,6 +20,7 @@ def csv_stdlib(fp):
     else:
         _set_dialect_quote_attrs(dialect, data)
 
+    del data
     reader = csv.DictReader(fp, dialect=dialect)
     columns = []
     # update the reader field names to avoid duplicate column names when performing row extraction
@@ -53,6 +54,7 @@ def csv_stdlib(fp):
     if not columns and not rows:
         raise EmptyTableError('Table empty or corrupt.', extension='csv')
 
+    del reader
     return {'Sheet 1': (columns, rows)}
 
 

--- a/mfr/extensions/tabular/render.py
+++ b/mfr/extensions/tabular/render.py
@@ -1,4 +1,5 @@
 import json
+import gc
 import logging
 import os
 
@@ -30,14 +31,23 @@ class TabularRenderer(extension.BaseRenderer):
             )
 
         with open(self.file_path, errors='replace') as fp:
-            sheets, size = self._render_grid(fp, self.metadata.ext)
-            return self.TEMPLATE.render(
-                base=self.assets_url,
-                width=settings.TABLE_WIDTH,
-                height=settings.TABLE_HEIGHT,
-                sheets=json.dumps(sheets),
-                options=json.dumps(size),
-            )
+            sheets, size, nbr_rows, nbr_cols = self._render_grid(fp, self.metadata.ext)
+            # gc.collect()
+            if sheets and size:
+                return self.TEMPLATE.render(
+                    base=self.assets_url,
+                    width=settings.TABLE_WIDTH,
+                    height=settings.TABLE_HEIGHT,
+                    sheets=json.dumps(sheets),
+                    options=json.dumps(size),
+                )
+        # gc.collect()
+        raise exceptions.TableTooBigError(
+            'Table is too large to render.',
+            extension=self.metadata.ext,
+            nbr_cols=nbr_cols,
+            nbr_rows=nbr_rows
+        )
 
     @property
     def file_required(self):
@@ -59,6 +69,11 @@ class TabularRenderer(extension.BaseRenderer):
         size = settings.SMALL_TABLE
         self._renderer_tabular_metrics['size'] = 'small'
         self._renderer_tabular_metrics['nbr_sheets'] = len(sheets)
+
+        table_too_big = False
+        nbr_cols = 0
+        nbr_rows = 0
+
         for sheet_title in sheets:
             sheet = sheets[sheet_title]
 
@@ -74,10 +89,13 @@ class TabularRenderer(extension.BaseRenderer):
 
             nbr_rows = len(sheet[1])
             if nbr_cols > settings.MAX_SIZE or nbr_rows > settings.MAX_SIZE:
-                raise exceptions.TableTooBigError('Table is too large to render.', extension=ext,
-                                                  nbr_cols=nbr_cols, nbr_rows=nbr_rows)
+                table_too_big = True
+                break
 
-        return sheets, size
+        if table_too_big:
+            return None, None, nbr_rows, nbr_cols
+
+        return sheets, size, None, None
 
     def _populate_data(self, fp, ext):
         """Determine the appropriate library and use it to populate rows and columns

--- a/mfr/extensions/tabular/render.py
+++ b/mfr/extensions/tabular/render.py
@@ -32,16 +32,20 @@ class TabularRenderer(extension.BaseRenderer):
 
         with open(self.file_path, errors='replace') as fp:
             sheets, size, nbr_rows, nbr_cols = self._render_grid(fp, self.metadata.ext)
-            # gc.collect()
-            if sheets and size:
-                return self.TEMPLATE.render(
-                    base=self.assets_url,
-                    width=settings.TABLE_WIDTH,
-                    height=settings.TABLE_HEIGHT,
-                    sheets=json.dumps(sheets),
-                    options=json.dumps(size),
+
+        # Force GC
+        gc.collect()
+
+        if sheets and size:
+            return self.TEMPLATE.render(
+                base=self.assets_url,
+                width=settings.TABLE_WIDTH,
+                height=settings.TABLE_HEIGHT,
+                sheets=json.dumps(sheets),
+                options=json.dumps(size),
                 )
-        # gc.collect()
+
+        assert nbr_rows and nbr_cols
         raise exceptions.TableTooBigError(
             'Table is too large to render.',
             extension=self.metadata.ext,
@@ -93,6 +97,7 @@ class TabularRenderer(extension.BaseRenderer):
                 break
 
         if table_too_big:
+            del sheets
             return None, None, nbr_rows, nbr_cols
 
         return sheets, size, None, None


### PR DESCRIPTION
* This doesn't solve the memory leak when `CSV` are correctly rendered. Need more investigation.
* This does significantly reduce the memory leak when `TableTooBigError` exception is thrown.