### PR TITLE
Ignore node_modules during lint

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,4 +8,4 @@
 [flake8]
 ignore = E501,E127,E128,E265,E301,E302,F403,E731
 max-line-length = 100
-exclude = .ropeproject,tests/*,src/*,env,venv
+exclude = .ropeproject,tests/*,src/*,env,venv,node_modules/*


### PR DESCRIPTION
## Purpose

Don't try and lint stuff in node_modules.

## Changes

Adds node_modules to the iexclude list for flake8

## Side effects


## QA Notes

<!-- If applicable, briefly describe how QA should test this ticket/PR -->

## Deployment Notes

<!-- Any special configurations for deployment? -->
