### PR TITLE
[SVCS-678] Add noop for export (Functionality Only)

### DIFF
--- a/mfr/server/handlers/export.py
+++ b/mfr/server/handlers/export.py
@@ -58,6 +58,13 @@ class ExportHandler(core.BaseHandler):
     async def get(self):
         """Export a file to the format specified via the associated extension library"""
 
+        # File is already in the requested format
+        if self.metadata.ext.lower() == ".{}".format(self.format.lower()):
+            await self.write_stream(await self.provider.download())
+            logger.info('Exported {} with no conversion.'.format(self.format))
+            self.metrics.add('export.conversion', 'noop')
+            return
+
         if settings.CACHE_ENABLED:
             try:
                 cached_stream = await self.cache_provider.download(self.cache_file_path)


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/SVCS-678

## Purpose

### What

When MFR receives an export request where the input and output formats are the same, it should simply return the original file unmodified... unless there's another reason to export the file (i.e. image scaling).

### Why

A no-op is a simple operation to support, why not do it?

### Acceptance criteria

A PR to support

## QA notes

Devs will test this. Dev, please add a list of affected and unaffected file types.

- this affects all file types. Any file type may now be exported. The extension of the file must match exactly the extension of the export, or we respond saying we cant export it. (i.e .jpg and .100\*100.jpg are not the same, and the 100\*100.jpg will trigger a actual file conversion)

Build an MFR export url requesting to export a file of type foo as type foo. This should start a download of the raw file without modification. Exception: image files should respect scaling parameters.