### PR TITLE
[No Ticket] Add get_object to interpret JSON settings

### DIFF
--- a/mfr/extensions/pdb/settings.py
+++ b/mfr/extensions/pdb/settings.py
@@ -2,7 +2,7 @@ from mfr import settings
 
 config = settings.child('PDB_EXTENSION_CONFIG')
 
-OPTIONS = config.get('OPTIONS', {
+OPTIONS = config.get_object('OPTIONS', {
     'width': 'auto',
     'height': '400',
     'antialias': True,

--- a/mfr/extensions/tabular/settings.py
+++ b/mfr/extensions/tabular/settings.py
@@ -9,7 +9,7 @@ MAX_SIZE = int(config.get('MAX_SIZE', 10000))  # max number of rows or columns a
 TABLE_WIDTH = int(config.get('TABLE_WIDTH', 700))
 TABLE_HEIGHT = int(config.get('TABLE_HEIGHT', 600))
 
-LIBS = config.get('LIBS', {
+LIBS = config.get_object('LIBS', {
     '.csv': [libs.csv_stdlib],
     '.tsv': [libs.csv_stdlib],
     '.gsheet': [libs.xlsx_xlrd],
@@ -21,7 +21,7 @@ LIBS = config.get('LIBS', {
     # '.ods': [libs.ods_ezodf],
 })
 
-SMALL_TABLE = config.get('SMALL_TABLE', {
+SMALL_TABLE = config.get_object('SMALL_TABLE', {
     'enableCellNavigation': True,
     'enableColumnReorder': False,
     'forceFitColumns': True,
@@ -29,7 +29,7 @@ SMALL_TABLE = config.get('SMALL_TABLE', {
     'multiColumnSort': True,
 })
 
-BIG_TABLE = config.get('BIG_TABLE', {
+BIG_TABLE = config.get_object('BIG_TABLE', {
     'enableCellNavigation': True,
     'enableColumnReorder': False,
     'syncColumnCellResize': True,

--- a/mfr/extensions/unoconv/settings.py
+++ b/mfr/extensions/unoconv/settings.py
@@ -13,7 +13,7 @@ PORT = config.get('PORT', os.environ.get('UNOCONV_PORT_2002_TCP_PORT', '2002'))
 
 DEFAULT_RENDER = {'renderer': '.pdf', 'format': 'pdf'}
 
-RENDER_MAP = config.get('RENDER_MAP', {
+RENDER_MAP = config.get_object('RENDER_MAP', {
     # 'csv': {'renderer': '.xlsx', 'format': 'xlsx'},
     # 'ppt': {'renderer': '.pdf', 'format': 'pdf'},
     # 'pptx': {'renderer': '.pdf', 'format': 'pdf'},

--- a/mfr/server/settings.py
+++ b/mfr/server/settings.py
@@ -27,10 +27,10 @@ PROVIDER_NAME = config.get('PROVIDER_NAME', 'osf')
 
 CACHE_ENABLED = config.get_bool('CACHE_ENABLED', False)
 CACHE_PROVIDER_NAME = config.get('CACHE_PROVIDER_NAME', 'filesystem')
-CACHE_PROVIDER_SETTINGS = config.get('CACHE_PROVIDER_SETTINGS', {'folder': '/tmp/mfr/'})
-CACHE_PROVIDER_CREDENTIALS = config.get('CACHE_PROVIDER_CREDENTIALS', {})
+CACHE_PROVIDER_SETTINGS = config.get_object('CACHE_PROVIDER_SETTINGS', {'folder': '/tmp/mfr/'})
+CACHE_PROVIDER_CREDENTIALS = config.get_object('CACHE_PROVIDER_CREDENTIALS', {})
 
-LOCAL_CACHE_PROVIDER_SETTINGS = config.get('LOCAL_CACHE_PROVIDER_SETTINGS', {'folder': '/tmp/mfrlocalcache/'})
+LOCAL_CACHE_PROVIDER_SETTINGS = config.get_object('LOCAL_CACHE_PROVIDER_SETTINGS', {'folder': '/tmp/mfrlocalcache/'})
 
 ALLOWED_PROVIDER_DOMAINS = config.get('ALLOWED_PROVIDER_DOMAINS', 'http://localhost:5000/ http://localhost:7777/').split(' ')
 ALLOWED_PROVIDER_NETLOCS = []

--- a/mfr/settings.py
+++ b/mfr/settings.py
@@ -69,6 +69,15 @@ class SettingsDict(dict):
         value = self.get(key, default)
         return None if value == '' else value
 
+    def get_object(self, key, default=None):
+        """Fetch a config value and interpret as a Python object or list. Since envvars are
+        always strings, interpret values of type `str` as JSON object or array. Otherwise assume
+        the type is already a python object."""
+        value = self.get(key, default)
+        if isinstance(value, str):
+            value = json.loads(value)
+        return value
+
     def full_key(self, key):
         """The name of the envvar which corresponds to this key."""
         return '{}_{}'.format(self.parent, key) if self.parent else key


### PR DESCRIPTION
## Ticket

N/A

## Purpose

Allow JSON objects and arrays to be passed into as environment variable settings, needed for Storage Internationalization project.

## Changes

Adds `get_object` to the base Settings class, **in the correct alphabetical order**.

## Side effects

None

## QA Notes

N/A

## Deployment Notes

Can now use JSON in environment variables, e.g.

```bash
export SERVER_CONFIG_CACHE_PROVIDER_SETTINGS='{
  "bucket": "cos-osf-stage-files-ca-1-mfr"
}'
```
