### PR TITLE
[SVCS-699] Write a stable id into generated pdfs

### DIFF
--- a/mfr/extensions/unoconv/export.py
+++ b/mfr/extensions/unoconv/export.py
@@ -1,6 +1,12 @@
 import os
 import subprocess
 
+from pdfrw import (
+    PdfReader,
+    PdfWriter
+)
+
+
 from mfr.core import extension
 from mfr.core import exceptions
 
@@ -20,6 +26,7 @@ class UnoconvExporter(extension.BaseExporter):
                 '-vvv',
                 self.source_file_path
             ], check=True, timeout=settings.UNOCONV_TIMEOUT)
+
         except subprocess.CalledProcessError as err:
             name, extension = os.path.splitext(os.path.split(self.source_file_path)[-1])
             raise exceptions.SubprocessError(
@@ -32,3 +39,8 @@ class UnoconvExporter(extension.BaseExporter):
                 extension=extension or '',
                 exporter_class='unoconv',
             )
+
+        pdf = PdfReader()
+        pdf.ID[0] = self.cache_file_id
+        pdf.ID[1] = self.source_file_id
+        PdfWriter(self.output_file_path, trailer=pdf).write()

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,7 @@ mistune==0.7
 
 # Pdf
 reportlab==3.4.0
+pdfrw==0.4.0
 
 # Pptx
 # python-pptx==0.5.7


### PR DESCRIPTION

> ## Blocked by [SVCS-678] Refactor and optimize handlers/extensions

<!-- Use the following format for the title of the Pull Request:

    [Status] [Ticket] Title

    - For PR ready for review, no need for status
    - For PR in progress, use [WIP]
    - For PR on hold, use [HOLD]
-->

<!-- Before submit your Pull Request, make sure you picked the right branch:

    - For hotfixes, select "master" as the target branch
    - For new features and improvements, select "develop" as the target branch
-->

<!-- For security related tickets, talk with the team lead before submit your PR -->

## Ticket

https://openscience.atlassian.net/secure/RapidBoard.jspa?rapidView=92&projectKey=SVCS&modal=detail&selectedIssue=SVCS-699

## Purpose

Write a stable id into generated pdfs, so that hypothesis annotations stay the same even through multiple rerenders.

## Changes

adds a requirement for pdfrw,
in the unoconv exporter, grab the ids for the original file and stick them into the pdf trailer on the id field.

## Side effects

unoconv exporter may take more time

## QA Notes

Check a bunch of pdfs and make sure they still convert properly

## Deployment Notes

<!-- Any special configurations for deployment? -->
