### PR TITLE
[No Ticket] Fix case-sensitive check for TIFF in PDF renderer

### DIFF
--- a/mfr/extensions/pdf/render.py
+++ b/mfr/extensions/pdf/render.py
@@ -21,7 +21,7 @@ class PdfRenderer(extension.BaseRenderer):
     def render(self):
         download_url = munge_url_for_localdev(self.metadata.download_url)
         logger.debug('extension::{}  supported-list::{}'.format(self.metadata.ext, settings.EXPORT_SUPPORTED))
-        if self.metadata.ext not in settings.EXPORT_SUPPORTED:
+        if self.metadata.ext.lower() not in settings.EXPORT_SUPPORTED:
             logger.debug('Extension not found in supported list!')
             return self.TEMPLATE.render(
                 base=self.assets_url,


### PR DESCRIPTION
## Ticket

No Ticket

The issue was discovered during CR and testing https://github.com/CenterForOpenScience/modular-file-renderer/pull/330

## Purpose

TIF/TIFF is both rendered and exported by the PDF renderer and exporter.
However, the renderer only allows .tif and .tiff to be exported but
accidentally leaves .TIF and .TIFF behind. They end up being rendered
directly as PDF which fails.

![tif-error](https://user-images.githubusercontent.com/3750414/41061591-16b14b8e-69a1-11e8-83df-c71db63e176e.png)

## Changes

`self.metadata.ext.l` -->> `self.metadata.ext.lower()`

## Side effects

No

## QA Notes

Both https://staging.osf.io/9ra6c/ and https://staging.osf.io/vprtu/ works on staging.

## Deployment Notes

No
