### PR TITLE
[SVCS-674] signal MFR action in WB metadata request

### DIFF
--- a/mfr/core/provider.py
+++ b/mfr/core/provider.py
@@ -14,7 +14,7 @@ class BaseProvider(metaclass=abc.ABCMeta):
     `mfr.server.settings.ALLOWED_PROVIDER_DOMAINS`.
     """
 
-    def __init__(self, request, url):
+    def __init__(self, request, url, action=None):
         self.request = request
         url_netloc = furl.furl(url).netloc
         if url_netloc not in settings.ALLOWED_PROVIDER_NETLOCS:
@@ -25,6 +25,7 @@ class BaseProvider(metaclass=abc.ABCMeta):
                 code=400
             )
         self.url = url
+        self.action = action
         self.provider_metrics = MetricsRecord('provider')
         self.metrics = self.provider_metrics.new_subrecord(self.NAME)
 

--- a/mfr/core/utils.py
+++ b/mfr/core/utils.py
@@ -4,7 +4,7 @@ from stevedore import driver
 from mfr.core import exceptions
 
 
-def make_provider(name, request, url):
+def make_provider(name, request, url, action=None):
     """Returns an instance of :class:`mfr.core.provider.BaseProvider`
 
     :param str name: The name of the provider to instantiate. (osf)
@@ -19,6 +19,7 @@ def make_provider(name, request, url):
             name=name.lower(),
             invoke_on_load=True,
             invoke_args=(request, url, ),
+            invoke_kwds={'action': action},
         ).driver
     except RuntimeError:
         raise exceptions.MakeProviderError(

--- a/mfr/providers/osf/provider.py
+++ b/mfr/providers/osf/provider.py
@@ -69,7 +69,11 @@ class OsfProvider(provider.BaseProvider):
         else:
             # URL is for WaterButler v1 API
             self.metrics.add('metadata.wb_api', 'v1')
-            metadata_response = await self._make_request('HEAD', download_url)
+            metadata_response = await self._make_request(
+                'HEAD',
+                download_url,
+                headers={settings.MFR_ACTION_HEADER: self.action or ''}
+            )
             response_code = metadata_response.status
             response_reason = metadata_response.reason
             response_headers = metadata_response.headers

--- a/mfr/providers/osf/provider.py
+++ b/mfr/providers/osf/provider.py
@@ -30,8 +30,8 @@ class OsfProvider(provider.BaseProvider):
     UNNEEDED_URL_PARAMS = ('_', 'token', 'action', 'mode', 'displayName')
     NAME = 'osf'
 
-    def __init__(self, request, url):
-        super().__init__(request, url)
+    def __init__(self, request, url, action=None):
+        super().__init__(request, url, action)
         self.download_url = None
         self.headers = {}
 

--- a/mfr/providers/osf/settings.py
+++ b/mfr/providers/osf/settings.py
@@ -4,3 +4,4 @@ from mfr import settings
 config = settings.child('OSF_PROVIDER_CONFIG')
 
 MFR_IDENTIFYING_HEADER = config.get('MFR_IDENTIFYING_HEADER', 'X-Cos-Mfr-Render-Request')
+MFR_ACTION_HEADER = config.get('MFR_ACTION_HEADER', 'X-Cos-Mfr-Request-Action')

--- a/mfr/server/handlers/core.py
+++ b/mfr/server/handlers/core.py
@@ -114,7 +114,8 @@ class BaseHandler(CorsMixin, tornado.web.RequestHandler, SentryMixin):
         self.provider = utils.make_provider(
             settings.PROVIDER_NAME,
             self.request,
-            self.url
+            self.url,
+            action=self.NAME,
         )
 
         self.metadata = await self.provider.metadata()


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/SVCS-674

## Purpose

Help OSF get more accurate MFR render/export statistics.

## Changes

When MFR requests metadata from WB, it should set a header identifying itself and indicating the type of MFR action being performed.  WB will relay that information to the OSF in the authorization request.  This will allow the OSF to distinguish contributor vs. non-contributor views and also avoid missing views due to MFR caching.

## Side effects

None expected.  Will do nothing until SVCS-831 is merged into WB.

## QA Notes

None.

## Deployment Notes

None.
