### PR TITLE
Ignore node_modules when running pytest

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,3 +9,6 @@
 ignore = E501,E127,E128,E265,E301,E302,F403,E731
 max-line-length = 100
 exclude = .ropeproject,tests/*,src/*,env,venv,node_modules/*
+
+[pytest]
+norecursedirs = .* build CVS _darcs {arch} *.egg venv node_modules/*


### PR DESCRIPTION
There are some python files in node_modeles, and these packages tests
shouldn't run when we run MFR tests.

<!-- Use the following format for the title of the Pull Request:

    [Status] [Ticket] Title

    - For PR ready for review, no need for status
    - For PR in progress, use [WIP]
    - For PR on hold, use [HOLD]
-->

<!-- Before submit your Pull Request, make sure you picked the right branch:

    - For hotfixes, select "master" as the target branch
    - For new features and improvements, select "develop" as the target branch
-->

<!-- For security related tickets, talk with the team lead before submit your PR -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/SVCS-1234 -->

## Purpose

<!-- Describe the purpose of your changes -->

## Changes

<!-- Briefly describe or list your changes  -->

## Side effects

<!-- Any possible side effects? -->

## QA Notes

<!-- If applicable, briefly describe how QA should test this ticket/PR -->

## Deployment Notes

<!-- Any special configurations for deployment? -->
