### PR TITLE
Fix hypothesis overlapping toolbar

### DIFF
--- a/mfr/extensions/pdf/templates/viewer.mako
+++ b/mfr/extensions/pdf/templates/viewer.mako
@@ -40,9 +40,8 @@ http://sourceforge.net/adobe/cmap/wiki/License/
 
     % if enable_hypothesis:
     <style>
-      body.show-hypothesis #toolbarViewer {
-        position: relative;
-        margin-right: 36px;
+      body.show-hypothesis .annotator-frame {
+        margin-top: 32px;
       }
     </style>
     % endif


### PR DESCRIPTION


## Ticket

https://openscience.atlassian.net/browse/SVCS-880

## Purpose

## Changes

The toolbar has a minimum size, so on mobile, the hypothesis bar overlaps with things on the pdf toolbar. This moves the hypothesis toolbar down by the height of the pdfjs toolbar so it doesn't obscure anything.

<!-- Describe the purpose of your changes -->


<!-- Briefly describe or list your changes  -->

## Side effects

The toolbar is moved down by 32 pixels, which it is not if using the hypothesis extension on a non-osf pdf.

## QA Notes

<!-- If applicable, briefly describe how QA should test this ticket/PR -->

## Deployment Notes

<!-- Any special configurations for deployment? -->
