### PR TITLE
Ft/docx rendering

### DIFF
--- a/mfr/core/exceptions.py
+++ b/mfr/core/exceptions.py
@@ -145,6 +145,25 @@ class MetadataError(ProviderError):
             'response': self.response
         }])
 
+
+class QueryParameterError(ProviderError):
+    """The MFR related errors raised from a :class:`mfr.core.provider` and relating to query parameters
+    should inherit from MetadataError
+    This error is thrown when a query parameter is used missused
+    """
+
+    __TYPE = 'query_parameter'
+
+    def __init__(self, message, *args, url: str='', code: int=400, **kwargs):
+        super().__init__(message, code=code, *args, **kwargs)
+        self.url = url
+        self.return_code = code
+        self.attr_stack.append([self.__TYPE, {
+            'url': self.url,
+            'returncode': self.return_code,
+        }])
+
+
 class TooBigToRenderError(ProviderError):
     """If the user tries to render a file larger than a server specified maximum, throw a
     TooBigToRenderError.

--- a/mfr/core/exceptions.py
+++ b/mfr/core/exceptions.py
@@ -147,9 +147,8 @@ class MetadataError(ProviderError):
 
 
 class QueryParameterError(ProviderError):
-    """The MFR related errors raised from a :class:`mfr.core.provider` and relating to query parameters
-    should inherit from MetadataError
-    This error is thrown when a query parameter is used missused
+    """The MFR related errors raised from a :class:`mfr.core.provider`and relating to query
+    parameters. This error is thrown when the query has an invalid value.
     """
 
     __TYPE = 'query_parameter'

--- a/mfr/core/exceptions.py
+++ b/mfr/core/exceptions.py
@@ -157,10 +157,13 @@ class QueryParameterError(ProviderError):
         super().__init__(message, code=code, *args, **kwargs)
         self.url = url
         self.return_code = code
-        self.attr_stack.append([self.__TYPE, {
-            'url': self.url,
-            'returncode': self.return_code,
-        }])
+        self.attr_stack.append([
+            self.__TYPE,
+            {
+                'url': self.url,
+                'returncode': self.return_code,
+            }
+        ])
 
 
 class TooBigToRenderError(ProviderError):

--- a/mfr/core/provider.py
+++ b/mfr/core/provider.py
@@ -49,18 +49,21 @@ class BaseProvider(metaclass=abc.ABCMeta):
 
 class ProviderMetadata:
 
-    def __init__(self, name, ext, content_type, unique_key, download_url, stable_id=None):
+    def __init__(self, name, ext, content_type, unique_key,
+                 download_url, is_public=False, stable_id=None):
         self.name = name
         self.ext = ext
         self.content_type = content_type
         self.unique_key = unique_key
         self.download_url = download_url
         self.stable_id = stable_id
+        self.is_public = is_public
 
     def serialize(self):
         return {
             'name': self.name,
             'ext': self.ext,
+            'is_public': self.is_public,
             'content_type': self.content_type,
             'unique_key': str(self.unique_key),
             'download_url': str(self.download_url),

--- a/mfr/core/provider.py
+++ b/mfr/core/provider.py
@@ -1,15 +1,19 @@
-import abc
+from abc import (
+    ABCMeta,
+    abstractmethod,
+    abstractproperty
+)
 
 from aiohttp import HttpBadRequest
-import furl
-import markupsafe
+from furl import furl
+from markupsafe import escape
 
-from mfr.core import exceptions as core_exceptions
+from mfr.core.exceptions import ProviderError
 from mfr.core.metrics import MetricsRecord
-from mfr.server import settings as server_settings
+from mfr.server.settings import ALLOWED_PROVIDER_NETLOCS
 
 
-class BaseProvider(metaclass=abc.ABCMeta):
+class BaseProvider(metaclass=ABCMeta):
     """Base class for MFR Providers.  Requires ``download`` and ``metadata`` methods.
     Validates that the given file url is hosted at a domain listed in
     `mfr.server.settings.ALLOWED_PROVIDER_DOMAINS`.
@@ -17,11 +21,11 @@ class BaseProvider(metaclass=abc.ABCMeta):
 
     def __init__(self, request, url, action=None):
         self.request = request
-        url_netloc = furl.furl(url).netloc
-        if url_netloc not in server_settings.ALLOWED_PROVIDER_NETLOCS:
-            raise core_exceptions.ProviderError(
+        netloc = furl(url).netloc
+        if netloc not in ALLOWED_PROVIDER_NETLOCS:
+            raise ProviderError(
                 message="{} is not a permitted provider domain.".format(
-                    markupsafe.escape(url_netloc)
+                    escape(netloc)
                 ),
                 # TODO: using HTTPStatus.BAD_REQUEST fails tests, not sure why and I will take a another look later
                 code=HttpBadRequest.code
@@ -36,15 +40,15 @@ class BaseProvider(metaclass=abc.ABCMeta):
             'url': str(self.url),
         })
 
-    @abc.abstractproperty
+    @abstractproperty
     def NAME(self):
         raise NotImplementedError
 
-    @abc.abstractmethod
+    @abstractmethod
     def metadata(self):
         pass
 
-    @abc.abstractmethod
+    @abstractmethod
     def download(self):
         pass
 

--- a/mfr/core/utils.py
+++ b/mfr/core/utils.py
@@ -78,6 +78,19 @@ def make_renderer(name, metadata, file_path, url, assets_url, export_url):
     :rtype: :class:`mfr.core.extension.BaseRenderer`
     """
     normalized_name = (name and name.lower()) or 'none'
+    if metadata.is_public:
+        try:
+            return driver.DriverManager(
+                namespace='mfr.public_renderers',
+                name=normalized_name,
+                invoke_on_load=True,
+                invoke_args=(metadata, file_path, url, assets_url, export_url),
+            ).driver
+        except:
+            # Check for a public renderer, if one doesn't exist, use a regular one
+            # Real exceptions handled by main driver.DriverManager
+            pass
+
     try:
         return driver.DriverManager(
             namespace='mfr.renderers',

--- a/mfr/core/utils.py
+++ b/mfr/core/utils.py
@@ -80,6 +80,7 @@ def make_renderer(name, metadata, file_path, url, assets_url, export_url):
     normalized_name = (name and name.lower()) or 'none'
     if metadata.is_public:
         try:
+            # Use the public renderer if exist
             return driver.DriverManager(
                 namespace='mfr.public_renderers',
                 name=normalized_name,
@@ -87,18 +88,19 @@ def make_renderer(name, metadata, file_path, url, assets_url, export_url):
                 invoke_args=(metadata, file_path, url, assets_url, export_url),
             ).driver
         except:
-            # Check for a public renderer, if one doesn't exist, use a regular one
-            # Real exceptions handled by main driver.DriverManager
+            # If public render does not exist, use default renderer by MFR
+            # If public render exists but exceptions occurs, delay the exception handling
             pass
 
     try:
+        # Use the default MFR handler
         return driver.DriverManager(
             namespace='mfr.renderers',
             name=normalized_name,
             invoke_on_load=True,
             invoke_args=(metadata, file_path, url, assets_url, export_url),
         ).driver
-    except RuntimeError:
+    except:
         raise exceptions.MakeRendererError(
             namespace='mfr.renderers',
             name=normalized_name,

--- a/mfr/extensions/office365/README.md
+++ b/mfr/extensions/office365/README.md
@@ -1,0 +1,20 @@
+
+# Office 365 Renderer
+
+
+This renderer uses Office Online to render .docx files for us. If the Office Online URL ever changes, it will also need to be changed here in settings.
+
+Currently there is no OSF side component for these changes. Once there is, this specific note can be removed. In the meantime in order to test this renderer, you need to go to your local OSF copy of this file: https://github.com/CenterForOpenScience/osf.io/blob/develop/addons/base/views.py#L728-L736
+and add 'public_file' : 1, to the dict. This will send all files as public files.
+
+Testing this renderer locally is hard. Since Office Online needs access to the files it will not work with private files or ones hosted locally. To see what the docx files will render like, replace the render function with something that looks like this:
+
+```
+    def render(self):
+        static_url = 'https://files.osf.io/v1/resources/<fake_project_id>/providers/osfstorage/<fake_file_id>'
+        url = settings.OFFICE_BASE_URL + download_url.url
+        return self.TEMPLATE.render(base=self.assets_url, url=url)
+
+```
+
+The file at `static_url` must be publicly available. 

--- a/mfr/extensions/office365/__init__.py
+++ b/mfr/extensions/office365/__init__.py
@@ -1,0 +1,1 @@
+from .render import Office365Renderer  # noqa

--- a/mfr/extensions/office365/render.py
+++ b/mfr/extensions/office365/render.py
@@ -1,0 +1,36 @@
+import os
+import furl
+
+from mfr.core import extension
+from mako.lookup import TemplateLookup
+from mfr.extensions.office365 import settings
+
+
+class Office365Renderer(extension.BaseRenderer):
+    """A renderer for use with public .docx files.
+
+    Office online can render .docx files to pdf for us.
+    This renderer will only ever be made if a query param with `public_file=1` is sent.
+    It then generates and embeds an office online url into an
+    iframe and returns the template. The file it is trying to render MUST
+    be available publically online. This renderer will not work if testing locally.
+
+    """
+
+    TEMPLATE = TemplateLookup(
+        directories=[
+            os.path.join(os.path.dirname(__file__), 'templates')
+        ]).get_template('viewer.mako')
+
+    def render(self):
+        download_url = furl.furl(self.metadata.download_url).set(query='')
+        url = settings.OFFICE_BASE_URL + download_url.url
+        return self.TEMPLATE.render(base=self.assets_url, url=url)
+
+    @property
+    def file_required(self):
+        return False
+
+    @property
+    def cache_result(self):
+        return False

--- a/mfr/extensions/office365/render.py
+++ b/mfr/extensions/office365/render.py
@@ -1,14 +1,14 @@
 import os
 from urllib import parse
 
-import furl
+from furl import furl
 from mako.lookup import TemplateLookup
 
-from mfr.core import extension
-from mfr.extensions.office365 import settings as office365_settings
+from mfr.core.extension import BaseRenderer
+from mfr.extensions.office365.settings import OFFICE_BASE_URL
 
 
-class Office365Renderer(extension.BaseRenderer):
+class Office365Renderer(BaseRenderer):
     """A renderer for .docx files that are publicly available.
 
     Office online can render `.docx` files to `.pdf` for us. This renderer will only be made
@@ -17,7 +17,6 @@ class Office365Renderer(extension.BaseRenderer):
     render MUST be public.
 
     Note: this renderer DOES NOT work locally.
-
     """
 
     TEMPLATE = TemplateLookup(
@@ -26,10 +25,11 @@ class Office365Renderer(extension.BaseRenderer):
         ]).get_template('viewer.mako')
 
     def render(self):
-        download_url = furl.furl(self.metadata.download_url).set(query='').url
-        encoded_download_url = parse.quote(download_url)
-        office_render_url = office365_settings.OFFICE_BASE_URL + encoded_download_url
-        return self.TEMPLATE.render(base=self.assets_url, url=office_render_url)
+        download_url = furl(self.metadata.download_url).set(query='').url
+        return self.TEMPLATE.render(
+            base=self.assets_url,
+            url=OFFICE_BASE_URL + parse.quote(download_url)
+        )
 
     @property
     def file_required(self):

--- a/mfr/extensions/office365/render.py
+++ b/mfr/extensions/office365/render.py
@@ -1,19 +1,22 @@
 import os
+from urllib import parse
+
 import furl
+from mako.lookup import TemplateLookup
 
 from mfr.core import extension
-from mako.lookup import TemplateLookup
-from mfr.extensions.office365 import settings
+from mfr.extensions.office365 import settings as office365_settings
 
 
 class Office365Renderer(extension.BaseRenderer):
-    """A renderer for use with public .docx files.
+    """A renderer for .docx files that are publicly available.
 
-    Office online can render .docx files to pdf for us.
-    This renderer will only ever be made if a query param with `public_file=1` is sent.
-    It then generates and embeds an office online url into an
-    iframe and returns the template. The file it is trying to render MUST
-    be available publically online. This renderer will not work if testing locally.
+    Office online can render `.docx` files to `.pdf` for us. This renderer will only be made
+    if a query param with `public_file=true` is present. It then generates and embeds an
+    office online URL into an `iframe` and returns the template. The file it is trying to
+    render MUST be public.
+
+    Note: this renderer DOES NOT work locally.
 
     """
 
@@ -23,9 +26,10 @@ class Office365Renderer(extension.BaseRenderer):
         ]).get_template('viewer.mako')
 
     def render(self):
-        download_url = furl.furl(self.metadata.download_url).set(query='')
-        url = settings.OFFICE_BASE_URL + download_url.url
-        return self.TEMPLATE.render(base=self.assets_url, url=url)
+        download_url = furl.furl(self.metadata.download_url).set(query='').url
+        encoded_download_url = parse.quote(download_url)
+        office_render_url = office365_settings.OFFICE_BASE_URL + encoded_download_url
+        return self.TEMPLATE.render(base=self.assets_url, url=office_render_url)
 
     @property
     def file_required(self):

--- a/mfr/extensions/office365/settings.py
+++ b/mfr/extensions/office365/settings.py
@@ -1,0 +1,6 @@
+from mfr import settings
+
+
+config = settings.child('OFFICE365_EXTENSION_CONFIG')
+
+OFFICE_BASE_URL = 'https://view.officeapps.live.com/op/embed.aspx?src='

--- a/mfr/extensions/office365/templates/viewer.mako
+++ b/mfr/extensions/office365/templates/viewer.mako
@@ -1,0 +1,11 @@
+<style>
+iframe {
+    width: 100%;
+    height: 800;
+}
+</style>
+
+<iframe src=${url} frameborder='0'></iframe>
+
+<script src="/static/js/mfr.js"></script>
+<script src="/static/js/mfr.child.js"></script>

--- a/mfr/providers/osf/provider.py
+++ b/mfr/providers/osf/provider.py
@@ -1,9 +1,10 @@
-import os
 import json
 import hashlib
+from http import HTTPStatus
 import logging
-from urllib.parse import urlparse
 import mimetypes
+import os
+from urllib.parse import urlparse
 
 import furl
 import aiohttp
@@ -11,12 +12,10 @@ from aiohttp.errors import ContentEncodingError
 
 from waterbutler.core import streams
 
-from mfr.core import exceptions
-from mfr.core import provider
-from mfr.core.utils import sizeof_fmt
-from mfr.providers.osf import settings
-from mfr.settings import MAX_FILE_SIZE_TO_RENDER
-from mfr.core.exceptions import TooBigToRenderError
+from mfr import settings as mfr_settings
+from mfr.core import exceptions as core_exceptions
+from mfr.core import provider, utils
+from mfr.providers.osf import settings as provider_settings
 
 logger = logging.getLogger(__name__)
 
@@ -79,14 +78,14 @@ class OsfProvider(provider.BaseProvider):
             response_reason = metadata_response.reason
             response_headers = metadata_response.headers
             await metadata_response.release()
-            if response_code != 200:
-                raise exceptions.MetadataError(
+            if response_code != HTTPStatus.OK:
+                raise core_exceptions.MetadataError(
                     'Failed to fetch file metadata from WaterButler. Received response: ',
                     'code {} {}'.format(str(response_code), str(response_reason)),
                     metadata_url=download_url,
                     response=response_reason,
                     provider=self.NAME,
-                    code=400
+                    code=HTTPStatus.BAD_REQUEST
                 )
 
             try:
@@ -111,12 +110,12 @@ class OsfProvider(provider.BaseProvider):
         name, ext = os.path.splitext(metadata['data']['name'])
         size = metadata['data']['size']
 
-        max_file_size = MAX_FILE_SIZE_TO_RENDER.get(ext)
+        max_file_size = mfr_settings.MAX_FILE_SIZE_TO_RENDER.get(ext)
         if max_file_size and size and int(size) > max_file_size:
-            raise TooBigToRenderError(
+            raise core_exceptions.TooBigToRenderError(
                 "This file with extension '{ext}' exceeds the size limit of {max_size} and will not "
                 "be rendered. To view this file download it and view it "
-                "offline.".format(ext=ext, max_size=sizeof_fmt(max_file_size)),
+                "offline.".format(ext=ext, max_size=utils.sizeof_fmt(max_file_size)),
                 requested_size=int(size), maximum_size=max_file_size,
             )
 
@@ -131,18 +130,16 @@ class OsfProvider(provider.BaseProvider):
         stable_id = hashlib.sha256(stable_str.encode('utf-8')).hexdigest()
         logger.debug('stable_identifier: str({}) hash({})'.format(stable_str, stable_id))
         is_public = False
-
-        if 'public_file' in cleaned_url.args:
-            if cleaned_url.args['public_file'] not in ['0', '1']:
-                raise exceptions.QueryParameterError(
-                    'The `public_file` query paramter should either `0`, `1`, or unused. Instead '
-                    'got  {}'.format(cleaned_url.args['public_file']),
+        public_file = cleaned_url.args.get('public_file', None)
+        if public_file:
+            if public_file not in ['True', 'False']:
+                raise core_exceptions.QueryParameterError(
+                    'Invalid value for query parameter `public_file`: {}'.format(cleaned_url.args['public_file']),
                     url=download_url,
                     provider=self.NAME,
-                    code=400,
+                    code=HTTPStatus.BAD_REQUEST,
                 )
-
-            is_public = cleaned_url.args['public_file'] == '1'
+            is_public = public_file == 'True'
 
         return provider.ProviderMetadata(
             name,
@@ -157,13 +154,13 @@ class OsfProvider(provider.BaseProvider):
     async def download(self):
         """Download file from WaterButler, returning stream."""
         download_url = await self._fetch_download_url()
-        headers = {settings.MFR_IDENTIFYING_HEADER: '1'}
+        headers = {provider_settings.MFR_IDENTIFYING_HEADER: '1'}
         response = await self._make_request('GET', download_url, allow_redirects=False, headers=headers)
 
-        if response.status >= 400:
+        if response.status >= HTTPStatus.BAD_REQUEST:
             resp_text = await response.text()
             logger.error('Unable to download file: ({}) {}'.format(response.status, resp_text))
-            raise exceptions.DownloadError(
+            raise core_exceptions.DownloadError(
                 'Unable to download the requested file, please try again later.',
                 download_url=download_url,
                 response=resp_text,
@@ -171,7 +168,7 @@ class OsfProvider(provider.BaseProvider):
             )
 
         self.metrics.add('download.saw_redirect', False)
-        if response.status in (302, 301):
+        if response.status in (HTTPStatus.MOVED_PERMANENTLY, HTTPStatus.FOUND):
             await response.release()
             response = await aiohttp.request('GET', response.headers['location'])
             self.metrics.add('download.saw_redirect', True)
@@ -204,8 +201,8 @@ class OsfProvider(provider.BaseProvider):
                 await request.release()
 
                 logger.debug('osf-download-resolver: request.status::{}'.format(request.status))
-                if request.status != 302:
-                    raise exceptions.MetadataError(
+                if request.status != HTTPStatus.FOUND:
+                    raise core_exceptions.MetadataError(
                         request.reason,
                         metadata_url=self.url,
                         provider=self.NAME,

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,9 @@ setup(
             'http = mfr.providers.http:HttpProvider',
             'osf = mfr.providers.osf:OsfProvider',
         ],
+        'mfr.public_renderers': [
+            '.docx = mfr.extensions.office365:Office365Renderer',
+        ],
         'mfr.exporters': [
             # google docs
             '.gdraw = mfr.extensions.image:ImageExporter',

--- a/tests/extensions/office365/test_renderer.py
+++ b/tests/extensions/office365/test_renderer.py
@@ -1,16 +1,23 @@
+from urllib import parse
+
 import furl
 import pytest
 
-from mfr.extensions.office365 import settings
 from mfr.core.provider import ProviderMetadata
 from mfr.extensions.office365 import Office365Renderer
+from mfr.extensions.office365 import settings as office365_settings
 
 
 @pytest.fixture
 def metadata():
-    return ProviderMetadata('test', '.pdf', 'text/plain', '1234',
+    return ProviderMetadata(
+        'test',
+        '.pdf',
+        'text/plain',
+        '1234',
         'http://wb.osf.io/file/test.pdf?token=1234&public_file=1',
-                                                        is_public=True)
+        is_public=True
+    )
 
 
 @pytest.fixture
@@ -20,7 +27,7 @@ def file_path():
 
 @pytest.fixture
 def url():
-    return 'http://osf.io/file/test.pdf'
+    return parse.quote('http://osf.io/file/test.pdf')
 
 
 @pytest.fixture
@@ -40,8 +47,8 @@ def renderer(metadata, file_path, url, assets_url, export_url):
 
 class TestOffice365Renderer:
 
-    def test_render_pdf(self, renderer, metadata, assets_url):
+    def test_render_pdf(self, renderer, metadata):
         download_url = furl.furl(metadata.download_url).set(query='')
-        body_url = settings.OFFICE_BASE_URL + download_url.url
+        office_render_url = office365_settings.OFFICE_BASE_URL + parse.quote(download_url.url)
         body = renderer.render()
-        assert '<iframe src={} frameborder=\'0\'></iframe>'.format(body_url) in body
+        assert '<iframe src={} frameborder=\'0\'></iframe>'.format(office_render_url) in body

--- a/tests/extensions/office365/test_renderer.py
+++ b/tests/extensions/office365/test_renderer.py
@@ -1,0 +1,47 @@
+import furl
+import pytest
+
+from mfr.extensions.office365 import settings
+from mfr.core.provider import ProviderMetadata
+from mfr.extensions.office365 import Office365Renderer
+
+
+@pytest.fixture
+def metadata():
+    return ProviderMetadata('test', '.pdf', 'text/plain', '1234',
+        'http://wb.osf.io/file/test.pdf?token=1234&public_file=1',
+                                                        is_public=True)
+
+
+@pytest.fixture
+def file_path():
+    return '/tmp/test.docx'
+
+
+@pytest.fixture
+def url():
+    return 'http://osf.io/file/test.pdf'
+
+
+@pytest.fixture
+def assets_url():
+    return 'http://mfr.osf.io/assets'
+
+
+@pytest.fixture
+def export_url():
+    return 'http://mfr.osf.io/export?url=' + url()
+
+
+@pytest.fixture
+def renderer(metadata, file_path, url, assets_url, export_url):
+    return Office365Renderer(metadata, file_path, url, assets_url, export_url)
+
+
+class TestOffice365Renderer:
+
+    def test_render_pdf(self, renderer, metadata, assets_url):
+        download_url = furl.furl(metadata.download_url).set(query='')
+        body_url = settings.OFFICE_BASE_URL + download_url.url
+        body = renderer.render()
+        assert '<iframe src={} frameborder=\'0\'></iframe>'.format(body_url) in body

--- a/tests/server/handlers/test_query_params.py
+++ b/tests/server/handlers/test_query_params.py
@@ -7,7 +7,7 @@ from tornado.httpclient import HTTPError
 from tests import utils
 
 
-class TestRenderHandler(utils.HandlerTestCase):
+class TestQueryParamsHandler(utils.HandlerTestCase):
 
     @testing.gen_test
     def test_format_url(self):


### PR DESCRIPTION
This is an update to https://github.com/CenterForOpenScience/modular-file-renderer/pull/304

## Ticket

https://openscience.atlassian.net/browse/SVCS-488
OSF side PR: https://github.com/CenterForOpenScience/osf.io/pull/8002

## Purpose

This ticket replaces https://github.com/CenterForOpenScience/modular-file-renderer/pull/282. Credit goes to @AddisonSchiller 🎆🎆.

`.docx` rendering is very intensive on the OSF. By using Microsoft's online rendering service to render publicly available `.docx` files, we can remove a lot of pressure from the `unoconv` container.

## Changes

* Added support for public renderers.
* Added the office365 renderer under the public renderers.
* Added support to parse for a `public_file` query param. This query param is optional.`public_file=True` denotes that the file is public (the project it belongs to is public) , while `public_file=False` denotes that it is private. All other values for `public_file` cause errors to be raised.
* `ProviderMetadata` now has an `is_public` flag, with default value set to `False`.

## Side Effects

* Does Microsoft enforces a rate limit?
* How can we handle the "a few hour" cache problem?
* What if this external service is down? Should we detect in advance?
* `iframe` sandboxing may cause issue, need to verify on staging.

## QA Notes

The Office365 renderer does not use the`.pdf` renderer like `unoconv` used to, so the pdfs that get made by this renderer may not display exactly the same. More QA notes to come. There is also a `README.md` in the renderer with more information about testing. 

## Deployment Notes

- [x] OSF side must be deployed first (no side effects).