### PR TITLE
Dont pass empty header

### DIFF
--- a/mfr/providers/osf/provider.py
+++ b/mfr/providers/osf/provider.py
@@ -73,7 +73,7 @@ class OsfProvider(provider.BaseProvider):
             metadata_response = await self._make_request(
                 'HEAD',
                 download_url,
-                headers={settings.MFR_ACTION_HEADER: self.action or ''}
+                headers=({settings.MFR_ACTION_HEADER: self.action} if self.action else None)
             )
             response_code = metadata_response.status
             response_reason = metadata_response.reason


### PR DESCRIPTION

## Ticket

No ticket

## Purpose

Tidies up the operation of a little bit of code.


<!-- Describe the purpose of your changes -->

## Changes

The OSF provider was passing a header with an empty value, this change
means the if the header is empty, then the header isn't sent at all.

This technically is a small optimization as well, it removes a few
instructions that would get called inside aiohttp. if this header was
here. (This is probably insignificant, however.)

## Side effects

OSF gets no header in this situation now

## QA Notes

<!-- If applicable, briefly describe how QA should test this ticket/PR -->

## Deployment Notes

<!-- Any special configurations for deployment? -->
