### PR TITLE
[HotFix] [SVCS-918] Use White Background For Zoomed Images

### DIFF
--- a/mfr/extensions/image/static/js/jquery.zoom.js
+++ b/mfr/extensions/image/static/js/jquery.zoom.js
@@ -4,10 +4,11 @@
  * Original Copy: https://github.com/jackmoore/zoom/blob/1.7.20/jquery.zoom.js
  * Version: https://github.com/jackmoore/zoom/releases/tag/1.7.20
  *
- * The are two MFR customizations in this file, one for style and one for functionality
+ * The are three MFR customizations in this file, two for style and one for functionality
  *
  * 1. Updated code style according to `.eslintrc.js`
  * 2. Added `.on("mousewheel", function (e) { ... })` to enable further zoom by mouse wheel scroll
+ * 3. Set "background-color: white" for "zoomImage" to handle images with transparent background
  */
 
 (function ($) {
@@ -53,6 +54,7 @@
                 top: 0,
                 left: 0,
                 opacity: 0,
+                "background-color": "white",
                 width: img.width * magnify,
                 height: img.height * magnify,
                 border: "none",


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/SVCS-918

## Purpose

cc and h/t @Johnetordoff for discovering this

Fix the issue where zooming does not work properly for `.GIF`s with transparent background. Here is the [example](https://staging.osf.io/3ca45/) on `staging` OSF.  This bug only affects non-exported types: `.GIF` and `.ICO`. For exported ones, the export type `.JPEG` does not have transparency so the background is set to white by default.

### Normal

![normal](https://user-images.githubusercontent.com/3750414/45736026-c6971700-bbb7-11e8-81b9-bc59acf0016b.png)

### Zoom - Before

![zoom](https://user-images.githubusercontent.com/3750414/45736027-c6971700-bbb7-11e8-9fad-31236fc253ce.png)

## Changes

- The fix simply set a white background when the zoom image's style class is generated on the page.

### Zoom - After

![zoom-fixed](https://user-images.githubusercontent.com/3750414/45736402-cb0fff80-bbb8-11e8-823f-ce20011a5e9f.png)

## Side effects

No

## QA Notes

Test that image rendering and zooming works as expected.

* `.GIF` with transparent background: https://staging.osf.io/3ca45/
* `.GIF` with non-transparent background: https://staging.osf.io/3r9m7/
* Plus a few other static images

## Deployment Notes

No
