### PR TITLE
[ENG-44] Add google analytics tracking for when hypothesis side panel is opened

### DIFF
--- a/mfr/extensions/pdf/render.py
+++ b/mfr/extensions/pdf/render.py
@@ -7,6 +7,7 @@ from mako.lookup import TemplateLookup
 from mfr.core import extension
 from mfr.extensions.pdf import settings
 from mfr.extensions.utils import munge_url_for_localdev, escape_url_for_template
+from mfr.settings import GOOGLE_ANALYTICS_TRACKING_ID
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +30,7 @@ class PdfRenderer(extension.BaseRenderer):
         if self.metadata.ext.lower() not in settings.EXPORT_SUPPORTED:
             logger.debug('Extension not found in supported list!')
             return self.TEMPLATE.render(
+                ga_tracking_id=GOOGLE_ANALYTICS_TRACKING_ID,
                 base=self.assets_url,
                 url=escape_url_for_template(download_url.geturl()),
                 stable_id=self.metadata.stable_id,
@@ -46,6 +48,7 @@ class PdfRenderer(extension.BaseRenderer):
 
         self.metrics.add('needs_export', True)
         return self.TEMPLATE.render(
+            ga_tracking_id=GOOGLE_ANALYTICS_TRACKING_ID,
             base=self.assets_url,
             url=escape_url_for_template(exported_url.url),
             stable_id=self.metadata.stable_id,

--- a/mfr/extensions/pdf/templates/viewer.mako
+++ b/mfr/extensions/pdf/templates/viewer.mako
@@ -426,6 +426,12 @@ http://sourceforge.net/adobe/cmap/wiki/License/
     <script>
         window.MFR_STABLE_ID = '${stable_id}';
         window.MFR_FILE_NAME = '${file_name}';
+        window.GA_TRACKING_ID = '${ga_tracking_id}';
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+        ga('create', window.GA_TRACKING_ID, 'auto');
     </script>
     <script src="/static/js/mfr.child.hypothesis.js"></script>
     % endif

--- a/mfr/server/static/js/mfr.child.hypothesis.js
+++ b/mfr/server/static/js/mfr.child.hypothesis.js
@@ -64,13 +64,24 @@
             hypothesisLoaded = true;
 
             var sidePanelOpened = false;
+            // window.DEFAULT_URL should be the wb link in this format:
+            // https://<wb-domain>/v1/resources/<preprint-guid>/providers/osfstorage/<file-id>?direct=&mode=render
+            // TODO: parse and validate the WB URL before retrieving the preprints GUID
+            var wbLink = window.DEFAULT_URL;
+            var preprintGuid;
+            if (wbLink.split('/').length >= 6) {
+                preprintGuid = wbLink.split('/')[5];
+            } else {
+                preprintGuid = 'preprint-guid-unknown';
+            }
             var sendAnalyticsIfExpanded = function (expanded) { 
                 if (expanded && !sidePanelOpened) {
                     sidePanelOpened = expanded;
                     ga('send', 'event', {
                         eventCategory: 'Hypothesis',
                         eventAction: 'Open Hypothesis Panel',
-                        eventLabel: window.DEFAULT_URL.split('/')[5],
+                        //`eventLabel` is the guid of the preprint to which the file belongs
+                        eventLabel: preprintGuid,
                     });
                 }
             };

--- a/mfr/server/static/js/mfr.child.hypothesis.js
+++ b/mfr/server/static/js/mfr.child.hypothesis.js
@@ -62,7 +62,23 @@
             window.document.head.appendChild(script);
             window.document.body.classList.add('show-hypothesis');
             hypothesisLoaded = true;
-        });
 
+            var sidePanelOpened = false;
+            var sendAnalyticsIfExpanded = function (expanded) { 
+                if (expanded && !sidePanelOpened) {
+                    sidePanelOpened = expanded;
+                    ga('send', 'event', {
+                        eventCategory: 'Hypothesis',
+                        eventAction: 'Open Hypothesis Panel',
+                        eventLabel: window.DEFAULT_URL.split('/')[5],
+                    });
+                }
+            };
+            window.hypothesisConfig = function () {
+                return {
+                  "onLayoutChange": function (layout) { return sendAnalyticsIfExpanded(layout.expanded); }
+                };
+            };
+        });
     };
 })();

--- a/mfr/settings.py
+++ b/mfr/settings.py
@@ -170,3 +170,4 @@ logging.config.dictConfig(logging_config)
 
 
 SENTRY_DSN = config.get_nullable('SENTRY_DSN', None)
+GOOGLE_ANALYTICS_TRACKING_ID = config.get_nullable('GOOGLE_ANALYTICS_TRACKING_ID', None)


### PR DESCRIPTION
## Ticket
https://openscience.atlassian.net/browse/ENG-44

## Purpose

To add GA tracking to MFR to track when users click open the Hypothesis panel.

## Changes
- In `mfr/extensions/pdf/templates/viewer.mako`, we add GA tracking imports.
- In `mfr/server/static/js/mfr.child.hypothesis.js`, we set `window.hypothesisConfig` to use the `onLayoutChange()` callback provided by hypothesis to watch for opening of annotation panel.
- Add GA tracking ID to settings and use that in renderer.

## Side effects

None

## QA Notes

Check to make sure the event is only tracked when users open the panel for the first time on that page. Page refresh counts as a new page. User is counted by browser, not OSF User. So if the same OSFUser opens two browser and opens the panel in both, it counts as two events.

## Deployment Notes

Add GOOGLE_ANALYTICS_TRACKING_ID for to staging/prod settings.
