### PR TITLE
[CR][ENG-379] update Dockerfile to be based on debian buster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
-FROM python:3.5-slim-stretch
+FROM python:3.5-slim-buster
 
 # ensure unoconv can locate the uno library
-ENV PYTHONPATH=/usr/lib/python3/dist-packages
+ENV PYTHONPATH /usr/lib/python3/dist-packages
 
 RUN usermod -d /home www-data \
     && chown www-data:www-data /home \
+    # -slim images strip man dirs, but java won't install unless this dir exists.
+    && mkdir -p /usr/share/man/man1 \
     && apt-get update \
     # mfr dependencies
     && apt-get install -y \
@@ -27,6 +29,8 @@ RUN usermod -d /home www-data \
         freecad \
         # pspp dependencies
         pspp \
+        # unoconv dependencies
+        libreoffice \
         # gosu dependencies
         curl \
         gnupg2 \
@@ -53,37 +57,8 @@ RUN usermod -d /home www-data \
     && rm -rf /var/lib/apt/lists/* \
     && pip install -U pip \
     && pip install setuptools==37.0.0 \
-    && mkdir -p /code
-
-ENV LIBREOFFICE_VERSION 6.1.6
-ENV LIBREOFFICE_ARCHIVE LibreOffice_6.1.6_Linux_x86-64_deb.tar.gz
-ENV LIBREOFFICE_MIRROR_URL https://download.documentfoundation.org/libreoffice/stable/
-RUN apt-get update \
-    && apt-get install -y \
-        curl \
-        gnupg2 \
-    && for server in hkp://ipv4.pool.sks-keyservers.net:80 \
-                     hkp://ha.pool.sks-keyservers.net:80 \
-                     hkp://pgp.mit.edu:80 \
-                     hkp://keyserver.pgp.com:80 \
-    ; do \
-      gpg --keyserver "$server" --recv-keys AFEEAEA3 && break || echo "Trying new server..." \
-    ; done \
-    && curl -SL "$LIBREOFFICE_MIRROR_URL/$LIBREOFFICE_VERSION/deb/x86_64/$LIBREOFFICE_ARCHIVE" -o $LIBREOFFICE_ARCHIVE \
-        && curl -SL "$LIBREOFFICE_MIRROR_URL/$LIBREOFFICE_VERSION/deb/x86_64/$LIBREOFFICE_ARCHIVE.asc" -o $LIBREOFFICE_ARCHIVE.asc \
-        && gpg --verify "$LIBREOFFICE_ARCHIVE.asc" \
-        && mkdir /tmp/libreoffice \
-        && tar -xvf "$LIBREOFFICE_ARCHIVE" -C /tmp/libreoffice/ --strip-components=1 \
-        && dpkg -i /tmp/libreoffice/**/*.deb \
-        && rm $LIBREOFFICE_ARCHIVE* \
-        && rm -Rf /tmp/libreoffice \
-    && apt-get clean \
-    && apt-get autoremove -y \
-        curl \
-        gnupg2 \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN pip install unoconv==0.8.2
+    && mkdir -p /code \
+    && pip install unoconv==0.8.2
 
 WORKDIR /code
 


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-379

## Purpose

Update base image to Debian Buster to allow installing LibreOffice from apt-get.

## Changes

Install libreoffice via apt-get instead of downloading `.deb` file from LO's archives.

## Side effects

None expected.  This can be tested/released independently of the [`docker-library` fix](https://github.com/CenterForOpenScience/docker-library/pull/51).

## QA Notes

Dev QA only.

## Deployment Notes

Nope.
