### PR TITLE
[WIP] [ForestFire] Improve .csv dialect sniffing

### DIFF
--- a/mfr/extensions/tabular/settings.py
+++ b/mfr/extensions/tabular/settings.py
@@ -4,10 +4,12 @@ from mfr.extensions.tabular import libs
 
 config = settings.child('TABULAR_EXTENSION_CONFIG')
 
-MAX_FILE_SIZE = int(config.get('MAX_FILE_SIZE', 10 * 1024 * 1024))  # 10Mb
+MAX_FILE_SIZE = int(config.get('MAX_FILE_SIZE', 10 * 1024 * 1024))  # 10MB
 MAX_SIZE = int(config.get('MAX_SIZE', 10000))  # max number of rows or columns allowed.
 TABLE_WIDTH = int(config.get('TABLE_WIDTH', 700))
 TABLE_HEIGHT = int(config.get('TABLE_HEIGHT', 600))
+
+TABULAR_INIT_SNIFF_SIZE = int(config.get('TABULAR_SNIFF_SIZE', 128))  # 4KB
 
 LIBS = config.get_object('LIBS', {
     '.csv': [libs.csv_stdlib],


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/SVCS-531

## Purpose

Improve .csv dialect sniffing.

## Changes

* Provide a full row of data to `csv.Sniffer().sniff()` so it can effectively detect the correct dialect. MFR reads a small amount of data from the file and recursively read more until either the following happens.
  * The sniff size goes over max render size allowed -> return renderer error
  * Any type of new line character found, trim (if necessary) and send the the full first row to the sniffer.

* - [ ] TODO: update unit tests

## Side effects

Memory usage for sniffing depends on the size of the first row of the file. In the worst case, it could sniff at most 10MB. Please note that we don't have enough statistical data on how many bytes the first row of a `.csv` file takes on average.

- [ ] TODO: maybe add a sentry alert when the sniffing size goes over 512KB

## QA Notes

TBD

## Deployment Notes

N / A
