### PR TITLE
[Hotfix] Remove old pin to certifi

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -53,5 +53,4 @@ scipy==0.19.1
 # Md
 markdown==2.6.2
 
-# Issue: certifi-2015.9.6.1 and 2015.9.6.2 fail verification (https://github.com/certifi/python-certifi/issues/26)
-certifi==2015.4.28
+certifi==2021.5.30

--- a/tasks.py
+++ b/tasks.py
@@ -6,25 +6,6 @@ WHEELHOUSE_PATH = os.environ.get('WHEELHOUSE')
 CONSTRAINTS_FILE = 'constraints.txt'
 
 
-def monkey_patch(ctx):
-    # Force an older cacert.pem from certifi v2015.4.28, prevents an ssl failure w/ identity.api.rackspacecloud.com.
-    #
-    # SubjectAltNameWarning: Certificate for identity.api.rackspacecloud.com has no `subjectAltName`, falling
-    # back to check for a `commonName` for now. This feature is being removed by major browsers and deprecated by
-    # RFC 2818. (See  https://github.com/shazow/urllib3/issues/497  for details.)
-    # SubjectAltNameWarning
-    import ssl
-    import certifi
-
-    _create_default_context = ssl.create_default_context
-
-    def create_default_context(purpose=ssl.Purpose.SERVER_AUTH, *, cafile=None, capath=None, cadata=None):
-        if cafile is None:
-            cafile = certifi.where()
-        return _create_default_context(purpose=purpose, cafile=cafile, capath=capath, cadata=cadata)
-    ssl.create_default_context = create_default_context
-
-
 @task
 def wheelhouse(ctx, develop=False):
     req_file = 'dev-requirements.txt' if develop else 'requirements.txt'
@@ -75,8 +56,6 @@ def test(ctx, verbose=False, nocov=False, extension=None, path=None):
 
 @task
 def server(ctx):
-    monkey_patch(ctx)
-
     if os.environ.get('REMOTE_DEBUG', None):
         import pydevd
         # e.g. '127.0.0.1:5678'


### PR DESCRIPTION
## Ticket

None.

## Purpose

The python module `certifi` was pinned to a very old version to work around issues with Rackspace. Not only is it no longer relevant, it can no longer successfully validate TLS certs.

## Changes
* Update `certifi` pin to latest release
* Remove `monkey_patch`

## Side effects
None expected

