### PR TITLE
fix: handle quotes in tabular sheet names

### DIFF
--- a/mfr/extensions/tabular/templates/viewer.mako
+++ b/mfr/extensions/tabular/templates/viewer.mako
@@ -33,7 +33,7 @@
 
         for (var sheetName in sheets){
             var sheet = sheets[sheetName];
-            sheetName = sheetName.replace( /(:|\.|\[|\]|,|@|&|\ )/g, '_' ); //Handle characters that can't be in DOM ID's
+            sheetName = sheetName.replace( /(:|\.|\[|\]|,|@|&|\ |'|")/g, '_' ); //Handle characters that can't be in DOM ID's
             $("#tabular-tabs").append('<li role="presentation" style="display:inline-block; float: none;"><a id="' + sheetName + '" aria-controls="' + sheetName + '" role="tab" data-toggle="tab">'+ sheetName + '</a></li>');
             gridArr[sheetName] = [sheet[0], sheet[1]];
 


### PR DESCRIPTION
<!-- Use the following format for the title of the Pull Request:

    [Status] [Ticket] Title

    - For PR ready for review, no need for status
    - For PR in progress, use [WIP]
    - For PR on hold, use [HOLD]
-->

<!-- Before submit your Pull Request, make sure you picked the right branch:

    - For hotfixes, select "master" as the target branch
    - For new features and improvements, select "develop" as the target branch
-->

<!-- For security related tickets, talk with the team lead before submit your PR -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/SVCS-1234 -->

## Purpose
avoid breaking when a spreadsheet name in a tabular file has an apostrophe
<!-- Describe the purpose of your changes -->

## Changes
add `'` and `"` to the special characters removed from sheet names
<!-- Briefly describe or list your changes  -->

## Side effects
ambiguity (duplicate dom ids) when two sheet names differ only by quote characters (extension of existing potential bug)
<!-- Any possible side effects? -->

## QA Notes

<!-- If applicable, briefly describe how QA should test this ticket/PR -->

## Deployment Notes

<!-- Any special configurations for deployment? -->
