### PR TITLE
Handle newer jasp files

### DIFF
--- a/mfr/extensions/jasp/render.py
+++ b/mfr/extensions/jasp/render.py
@@ -10,9 +10,6 @@ from .html_processor import HTMLProcessor
 
 class JASPRenderer(extension.BaseRenderer):
 
-    # Minimum data archive version supported
-    MINIMUM_VERSION = LooseVersion('1.0.2')
-
     TEMPLATE = TemplateLookup(
         directories=[
             os.path.join(os.path.dirname(__file__), 'templates')
@@ -23,7 +20,6 @@ class JASPRenderer(extension.BaseRenderer):
     def render(self):
         try:
             with ZipFile(self.file_path) as zip_file:
-                self._check_file(zip_file)
                 body = self._render_html(zip_file, self.metadata.ext)
                 return self.TEMPLATE.render(base=self.assets_url, body=body)
         except BadZipFile as err:
@@ -52,73 +48,10 @@ class JASPRenderer(extension.BaseRenderer):
                 '{} Missing index.html.'.format(self.MESSAGE_FILE_CORRUPT),
                 extension=self.metadata.ext,
                 corruption_type='key_error',
-                reason='zip missing ./index.html',
+                reason='jasp missing ./index.html',
             )
 
         processor = HTMLProcessor(zip_file)
         processor.feed(index)
 
         return processor.final_html()
-
-    def _check_file(self, zip_file):
-        """Check if the file is OK (not corrupt)
-        :param zip_file: an opened ZipFile representing the JASP file
-        :return: True
-        """
-        # Extract manifest file content
-        try:
-            with zip_file.open('META-INF/MANIFEST.MF') as manifest_data:
-                manifest = manifest_data.read().decode('utf-8')
-        except KeyError:
-            raise exceptions.JaspFileCorruptError(
-                '{} Missing META-INF/MANIFEST.MF'.format(self.MESSAGE_FILE_CORRUPT),
-                extension=self.metadata.ext,
-                corruption_type='key_error',
-                reason='zip missing ./META-INF/MANIFEST.MF',
-            )
-
-        lines = manifest.split('\n')
-
-        # Search for Data-Archive-Version
-        dataArchiveVersionStr, createdBy = None, ''
-        for line in lines:
-            keyValue = line.split(':')
-            if len(keyValue) == 2:
-                key = keyValue[0].strip()
-                value = keyValue[1].strip()
-                if key == 'Data-Archive-Version':
-                    dataArchiveVersionStr = value
-                elif key == 'Created-By':
-                    createdBy = str(value)
-        if not dataArchiveVersionStr:
-            raise exceptions.JaspFileCorruptError(
-                '{} Data-Archive-Version not found.'.format(self.MESSAGE_FILE_CORRUPT),
-                extension=self.metadata.ext,
-                corruption_type='manifest_parse_error',
-                reason='Data-Archive-Version not found.',
-            )
-
-        # Check that the file is new enough (contains preview content)
-        dataArchiveVersion = LooseVersion(dataArchiveVersionStr)
-        try:
-            if dataArchiveVersion < self.MINIMUM_VERSION:
-                minimum_version = self.MINIMUM_VERSION.vstring
-                data_archive_version = dataArchiveVersion.vstring
-                raise exceptions.JaspVersionError(
-                    'This JASP file was created with an older data archive '
-                    'version ({}) and cannot be previewed. Minimum data archive '
-                    'version is {}.'.format(data_archive_version, minimum_version),
-                    extension=self.metadata.ext,
-                    created_by=createdBy,
-                    actual_version=data_archive_version,
-                    required_version=minimum_version,
-                )
-        except TypeError:
-            raise exceptions.JaspFileCorruptError(
-                '{} Data-Archive-Version not parsable.'.format(self.MESSAGE_FILE_CORRUPT),
-                extension=self.metadata.ext,
-                corruption_type='manifest_parse_error',
-                reason='Data-Archive-Version ({}) not parsable.'.format(dataArchiveVersionStr),
-            )
-
-        return True

--- a/mfr/extensions/jasp/render.py
+++ b/mfr/extensions/jasp/render.py
@@ -4,7 +4,6 @@ from mako.lookup import TemplateLookup
 from mfr.core import extension
 from mfr.extensions.jasp import exceptions
 from zipfile import ZipFile, BadZipFile
-from distutils.version import LooseVersion
 
 from .html_processor import HTMLProcessor
 

--- a/tests/extensions/jasp/test_renderer.py
+++ b/tests/extensions/jasp/test_renderer.py
@@ -19,18 +19,6 @@ def not_a_zip_file_path():
     return os.path.join(os.path.dirname(os.path.abspath(__file__)), 'files', 'not-a-zip-file.jasp')
 
 @pytest.fixture
-def no_manifest_path():
-    return os.path.join(os.path.dirname(os.path.abspath(__file__)), 'files', 'no-manifest.jasp')
-
-@pytest.fixture
-def no_data_archive_version_in_manifest_path():
-    return os.path.join(os.path.dirname(os.path.abspath(__file__)), 'files', 'no-data-archive-version-in-manifest.jasp')
-
-@pytest.fixture
-def data_archive_version_is_too_old_path():
-    return os.path.join(os.path.dirname(os.path.abspath(__file__)), 'files', 'data-archive-version-is-too-old.jasp')
-
-@pytest.fixture
 def no_index_html_path():
     return os.path.join(os.path.dirname(os.path.abspath(__file__)), 'files', 'no-index_html.jasp')
 
@@ -73,33 +61,6 @@ class TestCodeJASPRenderer:
     def test_render_JASP_not_a_zip_file(self, metadata, not_a_zip_file_path, url, assets_url, export_url):
         try:
             renderer = JASPRenderer(metadata, not_a_zip_file_path, url, assets_url, export_url)
-            renderer.render()
-        except RendererError:
-            return
-
-        assert False # should not get here
-
-    def test_render_JASP_no_manifest(self, metadata, no_manifest_path, url, assets_url, export_url):
-        try:
-            renderer = JASPRenderer(metadata, no_manifest_path, url, assets_url, export_url)
-            renderer.render()
-        except RendererError:
-            return
-
-        assert False # should not get here
-
-    def test_render_JASP_no_data_archive_version_in_manifest(self, metadata, no_data_archive_version_in_manifest_path, url, assets_url, export_url):
-        try:
-            renderer = JASPRenderer(metadata, no_data_archive_version_in_manifest_path, url, assets_url, export_url)
-            renderer.render()
-        except RendererError:
-            return
-
-        assert False # should not get here
-
-    def test_render_JASP_data_archive_is_too_old(self, metadata, data_archive_version_is_too_old_path, url, assets_url, export_url):
-        try:
-            renderer = JASPRenderer(metadata, data_archive_version_is_too_old_path, url, assets_url, export_url)
             renderer.render()
         except RendererError:
             return


### PR DESCRIPTION
## Purpose

[JASP](https://github.com/jasp-stats/jasp-desktyop) files have been updated recently and could no longer be previewed on OSF. 

## Changes

This PR removes some superfluous check that allow the file renderer to show both old and new jasp-files.

## Problems
Me and my colleague @rensdofferhoff tried running the tests and renderer locally to test this.
But the versions request are all ancient and we could not get test to fail and this detected.

In other words, this is untested but we have no idea how to get it tested.
The changes are rather minimal though so it should just work.